### PR TITLE
Add temporizer command to pinocchio

### DIFF
--- a/cmd/pinocchio/cmds/temporizer/temporizer.go
+++ b/cmd/pinocchio/cmds/temporizer/temporizer.go
@@ -2,13 +2,16 @@ package temporizer
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/go-go-golems/glazed/pkg/helpers/files"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func NewTemporizerCommand() *cobra.Command {
-	var name, prefix string
+	var name, filePrefix, contentPrefix, contentSuffix string
 
 	cmd := &cobra.Command{
 		Use:   "temporizer",
@@ -24,19 +27,47 @@ func NewTemporizerCommand() *cobra.Command {
 				_, _ = fmt.Fprintln(os.Stderr, "Deleted files:", deletedFiles)
 			}
 
-			// Read from stdin and write to a temp file
-			tempFilePath, err := files.CopyReaderToTemporaryFile(prefix, name, os.Stdin)
+			// Create a temporary file
+			tempFile, err := files.CreateTemporaryFile(filePrefix, name)
 			if err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "Error writing to temporary file: %v\n", err)
+				_, _ = fmt.Fprintf(os.Stderr, "Error creating temporary file: %v\n", err)
+				os.Exit(1)
+			}
+			defer tempFile.Close()
+
+			// Write prefix content if specified
+			if contentPrefix != "" {
+				if !strings.HasSuffix(contentPrefix, "\n") {
+					contentPrefix += "\n"
+				}
+				if _, err := tempFile.WriteString(contentPrefix + "\n"); err != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "Error writing prefix content: %v\n", err)
+					os.Exit(1)
+				}
+			}
+
+			// Copy stdin content
+			if _, err := io.Copy(tempFile, os.Stdin); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error writing content: %v\n", err)
 				os.Exit(1)
 			}
 
-			fmt.Println(tempFilePath)
+			// Write suffix content if specified
+			if contentSuffix != "" {
+				if _, err := tempFile.WriteString("\n" + contentSuffix); err != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "Error writing suffix content: %v\n", err)
+					os.Exit(1)
+				}
+			}
+
+			fmt.Println(tempFile.Name())
 		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&name, "name", "n", "default", "Name of the temporary file")
-	cmd.PersistentFlags().StringVarP(&prefix, "prefix", "p", "temporizer", "Prefix for the temporary file")
+	cmd.PersistentFlags().StringVarP(&filePrefix, "file-prefix", "p", "temporizer", "Prefix for the temporary file name")
+	cmd.PersistentFlags().StringVar(&contentPrefix, "prefix", "", "Content to prepend to the input")
+	cmd.PersistentFlags().StringVar(&contentSuffix, "suffix", "", "Content to append to the input")
 
 	return cmd
 }

--- a/cmd/pinocchio/cmds/temporizer/temporizer.go
+++ b/cmd/pinocchio/cmds/temporizer/temporizer.go
@@ -1,0 +1,42 @@
+package temporizer
+
+import (
+	"fmt"
+	"github.com/go-go-golems/glazed/pkg/helpers/files"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+func NewTemporizerCommand() *cobra.Command {
+	var name, prefix string
+
+	cmd := &cobra.Command{
+		Use:   "temporizer",
+		Short: "Write stdin to a temporary file and print out its name",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Garbage Collect Existing Files
+			deletedFiles, err := files.GarbageCollectTemporaryFiles(os.TempDir(), "*.tmp", 10)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error in garbage collection: %v\n", err)
+				os.Exit(1)
+			}
+			if len(deletedFiles) > 0 {
+				_, _ = fmt.Fprintln(os.Stderr, "Deleted files:", deletedFiles)
+			}
+
+			// Read from stdin and write to a temp file
+			tempFilePath, err := files.CopyReaderToTemporaryFile(prefix, name, os.Stdin)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error writing to temporary file: %v\n", err)
+				os.Exit(1)
+			}
+
+			fmt.Println(tempFilePath)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&name, "name", "n", "default", "Name of the temporary file")
+	cmd.PersistentFlags().StringVarP(&prefix, "prefix", "p", "temporizer", "Prefix for the temporary file")
+
+	return cmd
+}

--- a/cmd/pinocchio/doc/doc.go
+++ b/cmd/pinocchio/doc/doc.go
@@ -1,0 +1,13 @@
+package doc
+
+import (
+	"embed"
+	"github.com/go-go-golems/glazed/pkg/help"
+)
+
+//go:embed *
+var docFS embed.FS
+
+func AddDocToHelpSystem(helpSystem *help.HelpSystem) error {
+	return helpSystem.LoadSectionsFromFS(docFS, ".")
+}

--- a/cmd/pinocchio/doc/general/01-temporizer.md
+++ b/cmd/pinocchio/doc/general/01-temporizer.md
@@ -1,0 +1,123 @@
+---
+Title: Temporizer - Creating temporary files
+Slug: temporizer
+Short: Using temporizer for managing temporary context files
+Topics:
+- temporizer
+- context
+- files
+- pinocchio
+- prompto
+Commands:
+- temporizer
+- pinocchio
+- prompto
+Flags:
+- name
+- file-prefix
+- prefix
+- suffix
+- context
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+## Overview
+
+Temporizer creates and manages temporary files from stdin, primarily used for passing context to other commands. It handles file cleanup automatically and provides options for file naming and content formatting.
+
+## Basic Usage
+
+Create a temporary file from stdin:
+```bash
+echo "data" | temporizer
+```
+
+The command outputs the path to the created temporary file.
+
+## Command Flags
+
+### Optional Flags
+
+`--name, -n <string>`
+- Sets identifier in filename
+- Default: "default"
+- Example: `--name context-1` → `/tmp/temporizer-context-1-<timestamp>`
+
+`--file-prefix, -p <string>`
+- Sets prefix for filename
+- Default: "temporizer"
+- Example: `--file-prefix myapp` → `/tmp/myapp-<name>-<timestamp>`
+
+`--prefix <string>`
+- Adds content before stdin data
+- Example: `--prefix "--- Context Start ---"`
+
+`--suffix <string>`
+- Adds content after stdin data
+- Example: `--suffix "--- Context End ---"`
+
+## Automatic Cleanup
+
+Temporizer includes built-in garbage collection that:
+- Maintains only the 10 most recent temporary files
+- Deletes older files based on modification time
+- Runs automatically before creating new files
+- Requires read/write permissions on temp directory
+- Reports deleted files to stderr
+
+## Integration with Pinocchio
+
+Temporizer is especially useful for providing context to LLM commands:
+
+```bash
+pinocchio code professional \
+    --context $(ppp glazed/writing-help-entries) \
+    --context $(git diff origin/main | temporizer)
+```
+
+Key components:
+1. `ppp` (alias for `prompto get --print-path`) retrieves prompto document paths
+2. `temporizer` captures dynamic content like git diffs
+3. Multiple context sources can be combined via --context flags
+
+## Common Usage Patterns
+
+With git changes:
+```bash
+git diff | temporizer --name git-changes
+```
+
+With API responses:
+```bash
+curl api.example.com | temporizer \
+  --name api-data \
+  --prefix "// Retrieved at $(date)" \
+  --suffix "// End of response"
+```
+
+Multiple context sources:
+```bash
+pinocchio code professional \
+  --context $(prompto get background --print-path) \
+  --context $(curl api.example.com/data | temporizer) \
+  --prompt "Analyze this data"
+```
+
+## File Management Details
+
+- Files stored in system temp directory
+- Unique filenames include timestamps
+- Automatic cleanup of older files
+- Reports cleanup actions to stderr
+- Non-zero exit code on errors
+
+## Output
+
+- Created file path printed to stdout
+- Cleanup/deleted files reported to stderr
+- Error messages sent to stderr
+
+This combination of automatic management and flexible options makes temporizer ideal for handling dynamic context in command pipelines, especially with LLM tools like Pinocchio.

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/prompto"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/temporizer"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/tokens"
+	pinocchio_docs "github.com/go-go-golems/pinocchio/cmd/pinocchio/doc"
 	"github.com/go-go-golems/pinocchio/pkg/cmds"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -109,6 +110,9 @@ func initRootCmd() (*help.HelpSystem, error) {
 	cobra.CheckErr(err)
 
 	err = clay.AddDocToHelpSystem(helpSystem)
+	cobra.CheckErr(err)
+
+	err = pinocchio_docs.AddDocToHelpSystem(helpSystem)
 	cobra.CheckErr(err)
 
 	helpSystem.SetupCobraRootCommand(rootCmd)

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/kagi"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/openai"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/prompto"
+	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/temporizer"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/tokens"
 	"github.com/go-go-golems/pinocchio/pkg/cmds"
 	"github.com/pkg/errors"
@@ -230,6 +231,10 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 		return err
 	}
 	rootCmd.AddCommand(cobraClipCommand)
+
+	// Add temporizer command
+	temporizerCmd := temporizer.NewTemporizerCommand()
+	rootCmd.AddCommand(temporizerCmd)
 
 	return nil
 }


### PR DESCRIPTION
This PR introduces the temporizer command to pinocchio, enhancing its
functionality for managing temporary context files. 

Usage example:
```bash
echo "data" | temporizer --name context-1 --prefix "Start" --suffix "End"
```