### PR TITLE
Add md-extract helper command for extracting content from markdown files

### DIFF
--- a/cmd/pinocchio/cmds/helpers/helpers.go
+++ b/cmd/pinocchio/cmds/helpers/helpers.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var helpersCmd = &cobra.Command{
+	Use:   "helpers",
+	Short: "Helper commands for common tasks",
+	Long:  "A collection of helper commands for common tasks like markdown processing.",
+}
+
+func RegisterHelperCommands(rootCmd *cobra.Command) error {
+	mdExtractCmd, err := NewExtractMdCommand()
+	if err != nil {
+		return err
+	}
+
+	mdExtractCobraCmd, err := cli.BuildCobraCommandFromCommand(mdExtractCmd)
+	if err != nil {
+		return err
+	}
+
+	helpersCmd.AddCommand(mdExtractCobraCmd)
+	rootCmd.AddCommand(helpersCmd)
+	return nil
+}

--- a/cmd/pinocchio/cmds/helpers/md-extract.go
+++ b/cmd/pinocchio/cmds/helpers/md-extract.go
@@ -1,0 +1,202 @@
+package helpers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/helpers/markdown"
+	"gopkg.in/yaml.v3"
+)
+
+type ExtractMdCommand struct {
+	*cmds.CommandDescription
+}
+
+type ExtractMdSettings struct {
+	Output           string   `glazed.parameter:"output"`
+	WithQuotes       bool     `glazed.parameter:"with-quotes"`
+	File             string   `glazed.parameter:"file"`
+	AllowedLanguages []string `glazed.parameter:"allowed-languages"`
+	BlockType        string   `glazed.parameter:"blocks"`
+}
+
+func NewExtractMdCommand() (*ExtractMdCommand, error) {
+	return &ExtractMdCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"md-extract",
+			cmds.WithShort("Extract code blocks from markdown"),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"output",
+					parameters.ParameterTypeChoice,
+					parameters.WithHelp("Output format"),
+					parameters.WithDefault("concatenated"),
+					parameters.WithChoices("concatenated", "list", "yaml"),
+				),
+				parameters.NewParameterDefinition(
+					"with-quotes",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Include code block quotes"),
+					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"allowed-languages",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("List of allowed languages to extract"),
+				),
+				parameters.NewParameterDefinition(
+					"blocks",
+					parameters.ParameterTypeChoice,
+					parameters.WithHelp("Type of blocks to extract"),
+					parameters.WithDefault("code"),
+					parameters.WithChoices("all", "normal", "code"),
+				),
+			),
+			cmds.WithArguments(
+				parameters.NewParameterDefinition(
+					"file",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Input file (use - for stdin)"),
+					parameters.WithDefault("-"),
+				),
+			),
+		),
+	}, nil
+}
+
+func (c *ExtractMdCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	s := &ExtractMdSettings{}
+	err := parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+	if err != nil {
+		return err
+	}
+
+	var input strings.Builder
+	var lastOutput string
+
+	processAndWrite := func(data string) error {
+		input.WriteString(data)
+		blocks := markdown.ExtractAllBlocks(input.String())
+		output, err := generateOutput(blocks, s)
+		if err != nil {
+			return err
+		}
+
+		if s.File == "-" {
+			newOutput := strings.TrimPrefix(output, lastOutput)
+			_, err = fmt.Fprint(w, newOutput)
+			lastOutput = output
+		} else {
+			_, err = fmt.Fprint(w, output)
+		}
+		return err
+	}
+
+	if s.File == "-" {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			if err := processAndWrite(scanner.Text() + "\n"); err != nil {
+				return err
+			}
+		}
+		return scanner.Err()
+	}
+
+	data, err := os.ReadFile(s.File)
+	if err != nil {
+		return err
+	}
+	return processAndWrite(string(data))
+}
+
+func generateOutput(blocks []markdown.MarkdownBlock, s *ExtractMdSettings) (string, error) {
+	var buf bytes.Buffer
+	bw := bufio.NewWriter(&buf)
+
+	isLanguageAllowed := func(lang string) bool {
+		if len(s.AllowedLanguages) == 0 {
+			return true
+		}
+		for _, allowed := range s.AllowedLanguages {
+			if allowed == lang {
+				return true
+			}
+		}
+		return false
+	}
+
+	isBlockTypeAllowed := func(block markdown.MarkdownBlock) bool {
+		switch s.BlockType {
+		case "all":
+			return true
+		case "normal":
+			return block.Type == markdown.Normal
+		case "code":
+			return block.Type == markdown.Code && isLanguageAllowed(block.Language)
+		default:
+			return false
+		}
+	}
+
+	switch s.Output {
+	case "concatenated":
+		for _, block := range blocks {
+			if !isBlockTypeAllowed(block) {
+				continue
+			}
+
+			if block.Type == markdown.Code && s.WithQuotes {
+				_, _ = fmt.Fprintf(bw, "```%s\n%s\n```\n", block.Language, block.Content)
+			} else {
+				_, _ = fmt.Fprintln(bw, block.Content)
+			}
+			bw.Flush() // Flush after each write
+		}
+	case "list":
+		for _, block := range blocks {
+			if !isBlockTypeAllowed(block) {
+				continue
+			}
+
+			if block.Type == markdown.Code {
+				_, _ = fmt.Fprintf(bw, "Language: %s\n", block.Language)
+				if s.WithQuotes {
+					_, _ = fmt.Fprintf(bw, "```%s\n%s\n```\n", block.Language, block.Content)
+				} else {
+					_, _ = fmt.Fprintln(bw, block.Content)
+				}
+			} else {
+				_, _ = fmt.Fprintf(bw, "Type: normal\n%s\n", block.Content)
+			}
+			_, _ = fmt.Fprintln(bw, "---")
+			bw.Flush() // Flush after each write
+		}
+	case "yaml":
+		filteredBlocks := make([]markdown.MarkdownBlock, 0)
+		for _, block := range blocks {
+			if isBlockTypeAllowed(block) {
+				filteredBlocks = append(filteredBlocks, block)
+			}
+		}
+		yamlEncoder := yaml.NewEncoder(bw)
+		err := yamlEncoder.Encode(filteredBlocks)
+		if err != nil {
+			return "", err
+		}
+		bw.Flush() // Flush after YAML encoding
+	}
+
+	bw.Flush()
+	return buf.String(), nil
+}

--- a/cmd/pinocchio/doc/general/02-md-extract.md
+++ b/cmd/pinocchio/doc/general/02-md-extract.md
@@ -1,0 +1,189 @@
+---
+Title: MD-Extract - Extract content from markdown files
+Slug: md-extract
+Short: Extract and process different types of blocks from markdown files
+Topics:
+- markdown
+- extraction
+- code blocks
+- text blocks
+- pinocchio
+Commands:
+- md-extract
+- pinocchio helpers
+Flags:
+- output
+- with-quotes
+- allowed-languages
+- blocks
+- file
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+## Overview
+
+MD-Extract is a utility for extracting and processing content from markdown files. It can extract code blocks, normal text blocks, or both, with various output formats and filtering options.
+
+## Basic Usage
+
+Extract code blocks from a markdown file:
+```bash
+pinocchio helpers md-extract --file input.md
+```
+
+Extract all blocks (code and normal text):
+```bash
+pinocchio helpers md-extract --file input.md --blocks all
+```
+
+Process markdown from stdin:
+```bash
+cat input.md | pinocchio helpers md-extract 
+```
+
+## Command Flags
+
+### Output Format
+
+`--output <string>`
+- Controls the output format
+- Choices: "concatenated", "list", "yaml"
+- Default: "concatenated"
+- Examples:
+  ```bash
+  # Simple concatenation of blocks
+  pinocchio helpers md-extract --file input.md --output concatenated
+
+  # Detailed list with block metadata
+  pinocchio helpers md-extract --file input.md --output list
+
+  # YAML format for structured processing
+  pinocchio helpers md-extract --file input.md --output yaml
+  ```
+
+### Block Selection
+
+`--blocks <string>`
+- Controls which types of blocks to extract
+- Choices: "all", "normal", "code"
+- Default: "code"
+- Examples:
+  ```bash
+  # Extract all blocks
+  pinocchio helpers md-extract --file input.md --blocks all
+
+  # Extract only normal text blocks
+  pinocchio helpers md-extract --file input.md --blocks normal
+
+  # Extract only code blocks (default)
+  pinocchio helpers md-extract --file input.md --blocks code
+  ```
+
+### Code Block Options
+
+`--with-quotes <bool>`
+- Include markdown code block quotes in output
+- Default: false
+- Example:
+  ```bash
+  pinocchio helpers md-extract --file input.md --with-quotes
+  ```
+
+`--allowed-languages <list>`
+- Filter code blocks by programming language
+- Optional: if not specified, all languages are included
+- Example:
+  ```bash
+  pinocchio helpers md-extract --file input.md --allowed-languages python,go
+  ```
+
+### Input Source
+
+`--file <string>`
+- Input file path (use "-" for stdin)
+- Default: "-"
+- Examples:
+  ```bash
+  # Read from file
+  pinocchio helpers md-extract --file README.md
+
+  # Read from stdin
+  cat README.md | pinocchio helpers md-extract --file -
+  ```
+
+## Output Formats
+
+### Concatenated (Default)
+
+Outputs blocks one after another:
+```
+// For code blocks with --with-quotes
+```python
+def hello():
+    print("Hello")
+```
+
+// For code blocks without --with-quotes
+def hello():
+    print("Hello")
+
+// For normal text blocks
+This is a normal text block.
+```
+
+### List
+
+Outputs blocks with metadata:
+```
+Language: python
+```python
+def hello():
+    print("Hello")
+```
+---
+Type: normal
+This is a normal text block.
+---
+```
+
+### YAML
+
+Outputs blocks in structured YAML format:
+```yaml
+- type: code
+  language: python
+  content: |
+    def hello():
+        print("Hello")
+- type: normal
+  content: This is a normal text block.
+```
+
+## Common Use Cases
+
+1. **Extract Code Examples**
+   ```bash
+   # Extract Python code examples from documentation
+   pinocchio helpers md-extract --file docs.md --allowed-languages python
+   ```
+
+2. **Documentation Processing**
+   ```bash
+   # Extract all content in structured format
+   pinocchio helpers md-extract --file README.md --blocks all --output yaml
+   ```
+
+3. **Code Block Collection**
+   ```bash
+   # Collect all code blocks with language markers
+   pinocchio helpers md-extract --file tutorial.md --with-quotes
+   ```
+
+4. **Text Content Extraction**
+   ```bash
+   # Extract only text content
+   pinocchio helpers md-extract --file article.md --blocks normal
+   ```

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -20,6 +20,7 @@ import (
 	pinocchio_cmds "github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/catter"
 	catter_doc "github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/catter/pkg/doc"
+	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/helpers"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/kagi"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/openai"
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/prompto"
@@ -239,6 +240,12 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 	// Add temporizer command
 	temporizerCmd := temporizer.NewTemporizerCommand()
 	rootCmd.AddCommand(temporizerCmd)
+
+	// Add helper commands
+	err = helpers.RegisterHelperCommands(rootCmd)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-go-golems/bobatea v0.0.11
 	github.com/go-go-golems/clay v0.1.20
 	github.com/go-go-golems/geppetto v0.4.23
-	github.com/go-go-golems/glazed v0.5.21
+	github.com/go-go-golems/glazed v0.5.22
 	github.com/go-go-golems/prompto v0.1.6
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/go-go-golems/clay v0.1.20 h1:KUTbDBA/Q7vgG22B9uBnwDpacwG2+bMavQS8SDwo
 github.com/go-go-golems/clay v0.1.20/go.mod h1:hyQirWoEICmaSTcAiPRy7If1n5JEncPi4WVM6tivjoY=
 github.com/go-go-golems/geppetto v0.4.23 h1:cGqWqbTPWOzdA/DZ+TLkraBlsHaY+lAzQundQYOIUFg=
 github.com/go-go-golems/geppetto v0.4.23/go.mod h1:EcQOt0Kiv1PtMaT58l1kJ9EPdSemfBuevmqie98T3HA=
-github.com/go-go-golems/glazed v0.5.21 h1:irOl46wwnSvFd7o+1WJz23WNJ7PpIhV5hrUpRtanZiA=
-github.com/go-go-golems/glazed v0.5.21/go.mod h1:cceXzXliF/CEc8qM/YXhcp9AbBAQpKDMF3+HIlGTDAI=
+github.com/go-go-golems/glazed v0.5.22 h1:Nns2zOdg1XptPPNWJbT3QWn5IeYp76gb2lAT4wVlNao=
+github.com/go-go-golems/glazed v0.5.22/go.mod h1:cceXzXliF/CEc8qM/YXhcp9AbBAQpKDMF3+HIlGTDAI=
 github.com/go-go-golems/prompto v0.1.6 h1:nIYsVmzcrmVmLXA4gxx3Ri32Pq1kAMr9jw8N3AjHhNM=
 github.com/go-go-golems/prompto v0.1.6/go.mod h1:Bn0X8QAAAI4kLDcDqO6Hd4Peh+Mu3siDm/6dsj3VO4A=
 github.com/go-go-golems/sqleton v0.2.4 h1:qsgX0RxBXdjOC/+zmRrVvlsbBT8HCM2otLh/bV/f5uU=


### PR DESCRIPTION
This PR introduces a new helper command `md-extract` for extracting and 
processing content from markdown files. Key features include:

- Extract code blocks, normal text blocks, or both
- Multiple output formats: concatenated, list, and YAML
- Filter code blocks by programming language
- Option to include or exclude markdown code block quotes
- Process input from files or stdin
- Flexible block selection (all, normal, or code blocks)