### PR TITLE
Add autosave functionality for conversation histories

### DIFF
--- a/cmd/pinocchio/doc/general/03-autosave.md
+++ b/cmd/pinocchio/doc/general/03-autosave.md
@@ -1,6 +1,6 @@
 ---
 Title: Autosaving Conversations in Pinocchio
-Slug: autosave-functionality
+Slug: autosave
 Short: Configure automatic saving of conversation histories
 Topics:
 - configuration

--- a/cmd/pinocchio/doc/general/03-autosave.md
+++ b/cmd/pinocchio/doc/general/03-autosave.md
@@ -1,0 +1,72 @@
+---
+Title: Autosaving Conversations in Pinocchio
+Slug: autosave-functionality
+Short: Configure automatic saving of conversation histories
+Topics:
+- configuration
+- persistence
+- history
+Commands:
+- pinocchio
+Flags:
+- autosave
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Pinocchio can automatically save your conversation histories to persistent storage. This allows you to review past conversations and maintain a record of your interactions.
+
+## Configuration
+
+### Command Line
+
+Set autosave options using the `--autosave` flag with key-value pairs:
+
+```bash
+pinocchio --autosave enabled:yes,path:/custom/path,template:{{.Time.Format "150405"}}-{{.ConversationID}}.json
+```
+
+Available options:
+- `enabled`: "yes" or "no" (default: "no")
+- `path`: Directory path string for save location (default: `~/.pinocchio/history`)
+- `template`: Custom template pattern for filename (default: `{{.Year}}/{{.Month}}/{{.Day}}/{{.Time.Format "150405"}}-{{.ConversationID}}.json`)
+
+### Configuration File
+
+Add to `~/.pinocchio/config.yaml`:
+
+```yaml
+autosave:
+  enabled: yes
+  path: /custom/path/to/history  # optional
+  template: custom-template      # optional
+```
+
+## Path Templates
+
+The save path supports Go template syntax with these variables:
+- `{{.Year}}`: Year (YYYY)
+- `{{.Month}}`: Month (MM)
+- `{{.Day}}`: Day (DD)
+- `{{.Time}}`: Conversation start time
+- `{{.ConversationID}}`: Unique conversation identifier
+
+## Default Behavior
+
+When enabled without a custom path:
+- Creates `~/.pinocchio/history` directory
+- Organizes files by date: `YYYY/MM/DD`
+- Names files with timestamp and conversation ID
+- Saves as JSON format
+
+## File Structure
+
+Each save file contains:
+- Complete conversation history
+- Message timestamps
+- Conversation tree structure
+- Unique conversation identifier
+
+This allows for future browsing, searching, and analysis of conversation histories.

--- a/cmd/pinocchio/prompts/code/create-commit-message.yaml
+++ b/cmd/pinocchio/prompts/code/create-commit-message.yaml
@@ -29,7 +29,7 @@ flags:
     type: string
     help: Description or reference to the issue corresponding to this commit
   - name: diff
-    type: stringFromFile
+    type: file
     help: File containing the diff of the changes
   - name: code
     type: fileList
@@ -47,7 +47,7 @@ prompt: |
   
   {{if .diff }}The diff of the changes is:
   --- BEGIN DIFF
-  {{ .diff }}
+  {{ .diff.Content }}
   --- END DIFF. {{ end }}
   
   {{ if .code }}The modified code files are:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dave/jennifer v1.7.0
 	github.com/go-go-golems/bobatea v0.0.11
 	github.com/go-go-golems/clay v0.1.20
-	github.com/go-go-golems/geppetto v0.4.23
+	github.com/go-go-golems/geppetto v0.4.24
 	github.com/go-go-golems/glazed v0.5.22
 	github.com/go-go-golems/prompto v0.1.6
 	github.com/google/uuid v1.6.0
@@ -116,7 +116,7 @@ require (
 	github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 // indirect
 	github.com/xuri/excelize/v2 v2.7.1 // indirect
 	github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22 // indirect
-	github.com/yuin/goldmark v1.7.4 // indirect
+	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.3 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/go-go-golems/bobatea v0.0.11 h1:ceUdMEXGhwYiXMyeW4Ym/XNbuKygKyFqpGbJh
 github.com/go-go-golems/bobatea v0.0.11/go.mod h1:M/qOKNefggUgAvKSqDSOGhaVfStcAG4GcZqgwac0SLo=
 github.com/go-go-golems/clay v0.1.20 h1:KUTbDBA/Q7vgG22B9uBnwDpacwG2+bMavQS8SDwolks=
 github.com/go-go-golems/clay v0.1.20/go.mod h1:hyQirWoEICmaSTcAiPRy7If1n5JEncPi4WVM6tivjoY=
-github.com/go-go-golems/geppetto v0.4.23 h1:cGqWqbTPWOzdA/DZ+TLkraBlsHaY+lAzQundQYOIUFg=
-github.com/go-go-golems/geppetto v0.4.23/go.mod h1:EcQOt0Kiv1PtMaT58l1kJ9EPdSemfBuevmqie98T3HA=
+github.com/go-go-golems/geppetto v0.4.24 h1:vzAJgZsyzHPOtvi7BSQYmMX/K9FpiB4ZmQjO4pDbo10=
+github.com/go-go-golems/geppetto v0.4.24/go.mod h1:oPdBF6gmsZzQnAa9RpOF+tMa/K/KK9t9yKObJuQzUHY=
 github.com/go-go-golems/glazed v0.5.22 h1:Nns2zOdg1XptPPNWJbT3QWn5IeYp76gb2lAT4wVlNao=
 github.com/go-go-golems/glazed v0.5.22/go.mod h1:cceXzXliF/CEc8qM/YXhcp9AbBAQpKDMF3+HIlGTDAI=
 github.com/go-go-golems/prompto v0.1.6 h1:nIYsVmzcrmVmLXA4gxx3Ri32Pq1kAMr9jw8N3AjHhNM=
@@ -278,8 +278,8 @@ github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22 h1:OAmKAfT06//esDdpi/DZ8Q
 github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
-github.com/yuin/goldmark v1.7.4 h1:BDXOHExt+A7gwPCJgPIIq7ENvceR7we7rOS9TNoLZeg=
-github.com/yuin/goldmark v1.7.4/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
+github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark-emoji v1.0.3 h1:aLRkLHOuBR2czCY4R8olwMjID+tENfhyFDMCRhbIQY4=
 github.com/yuin/goldmark-emoji v1.0.3/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
 github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04 h1:qXafrlZL1WsJW5OokjraLLRURHiw0OzKHD/RNdspp4w=

--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -2,6 +2,8 @@ package cmds
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/claude"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
@@ -11,7 +13,6 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/middlewares"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func BuildCobraCommandWithGeppettoMiddlewares(
@@ -82,6 +83,7 @@ func GetCobraCommandGeppettoMiddlewares(
 				settings.AiClientSlug,
 				openai.OpenAiChatSlug,
 				claude.ClaudeChatSlug,
+				GeppettoHelpersSlug,
 			},
 			middlewares.GatherFlagsFromViper(parameters.WithParseStepSource("viper")),
 		),

--- a/pkg/ui/backend.go
+++ b/pkg/ui/backend.go
@@ -3,8 +3,9 @@ package ui
 import (
 	"context"
 	"fmt"
+
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 	boba_chat "github.com/go-go-golems/bobatea/pkg/chat"
 	conversation2 "github.com/go-go-golems/bobatea/pkg/chat/conversation"
 	"github.com/go-go-golems/geppetto/pkg/conversation"
@@ -18,6 +19,8 @@ type StepBackend struct {
 	stepFactory chat.Step
 	stepResult  steps.StepResult[string]
 }
+
+var _ boba_chat.Backend = &StepBackend{}
 
 func (s *StepBackend) Start(ctx context.Context, msgs []*conversation.Message) (tea.Cmd, error) {
 	if !s.IsFinished() {
@@ -74,6 +77,8 @@ func (s *StepBackend) IsFinished() bool {
 
 var _ boba_chat.Backend = &StepBackend{}
 
+// StepChatForwardFunc is a function that forwards watermill messages to the UI by
+// trasnforming them into bubbletea messages and injecting them into the program `p`.
 func StepChatForwardFunc(p *tea.Program) func(msg *message.Message) error {
 	return func(msg *message.Message) error {
 		msg.Ack()


### PR DESCRIPTION
This PR introduces autosave functionality for conversation histories in 
Pinocchio. Key changes include:

- New autosave configuration options:
  - Enable/disable autosave
  - Custom save path
  - Custom filename template
- Default save location: ~/.pinocchio/history
- File organization by date: YYYY/MM/DD
- JSON format for saved conversations
- Configurable via command line flags or config file