### PR TITLE
Refactor chat handling and add direct chat startup option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,12 +41,25 @@
             }
         },
         {
+            "name": "Pinocchio Test Terminal",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/pinocchio",
+            "args": ["examples", "test"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "env": {
+                "PINOCCHIO_PROFILE": "haiku"
+            }
+        },
+        {
             "name": "Pinocchio Test UI",
             "type": "go",
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/cmd/pinocchio",
-            "args": ["examples", "test", "--chat", "--force-interactive"],
+            "args": ["examples", "test", "--chat"],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "env": {

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-go-golems/pinocchio/cmd/pinocchio/cmds/tokens"
 	pinocchio_docs "github.com/go-go-golems/pinocchio/cmd/pinocchio/doc"
 	"github.com/go-go-golems/pinocchio/pkg/cmds"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -173,7 +174,7 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 		rootCmd,
 		repositories_,
 		cli.WithCobraMiddlewaresFunc(cmds.GetCobraCommandGeppettoMiddlewares),
-		cli.WithCobraShortHelpLayers(layers.DefaultSlug, cmds.GeppettoHelpersSlug),
+		cli.WithCobraShortHelpLayers(layers.DefaultSlug, cmdlayers.GeppettoHelpersSlug),
 	)
 	if err != nil {
 		return err

--- a/cmd/pinocchio/prompts/examples/test.yaml
+++ b/cmd/pinocchio/prompts/examples/test.yaml
@@ -14,6 +14,6 @@ flags:
     type: string
     default: "you"
     help: Of what am I asking?
-system_prompt: You are a LLM.
+system-prompt: You are a LLM.
 prompt: |
   Pretend you are a {{.pretend}}. What is the {{.what}} of {{.of}}? 2 words.

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/dave/jennifer v1.7.0
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
-	github.com/go-go-golems/bobatea v0.0.12
+	github.com/go-go-golems/bobatea v0.0.13
 	github.com/go-go-golems/clay v0.1.20
-	github.com/go-go-golems/geppetto v0.4.27
+	github.com/go-go-golems/geppetto v0.4.28
 	github.com/go-go-golems/glazed v0.5.23
 	github.com/go-go-golems/prompto v0.1.7
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -91,12 +91,12 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-go-golems/bobatea v0.0.12 h1:tOVgZQ+xmIOgLZvaqgjoz8F8sD+LsdWNuqymiaSusao=
-github.com/go-go-golems/bobatea v0.0.12/go.mod h1:+mgkJU0P1rYRq6SwKkFD6FhGAVc+QIDCR/VMKOsU4fI=
+github.com/go-go-golems/bobatea v0.0.13 h1:eJBEVML2pSsHVtiqdJpTRvMnDhtI6Kp7gLiBd+LM3pI=
+github.com/go-go-golems/bobatea v0.0.13/go.mod h1:+mgkJU0P1rYRq6SwKkFD6FhGAVc+QIDCR/VMKOsU4fI=
 github.com/go-go-golems/clay v0.1.20 h1:KUTbDBA/Q7vgG22B9uBnwDpacwG2+bMavQS8SDwolks=
 github.com/go-go-golems/clay v0.1.20/go.mod h1:hyQirWoEICmaSTcAiPRy7If1n5JEncPi4WVM6tivjoY=
-github.com/go-go-golems/geppetto v0.4.27 h1:xDJjrhRGQ1fi942/bTFoacnVUzsAz5kHKk8rp0sD5Oc=
-github.com/go-go-golems/geppetto v0.4.27/go.mod h1:cAv9cYbPNrH9gdqmoefC93p//E7xgqQtDXd0KSmHzS0=
+github.com/go-go-golems/geppetto v0.4.28 h1:0KUCd5DeP4KzNUUZ/5hmMD2kSFRYCr+hN0kl5bWhesA=
+github.com/go-go-golems/geppetto v0.4.28/go.mod h1:cAv9cYbPNrH9gdqmoefC93p//E7xgqQtDXd0KSmHzS0=
 github.com/go-go-golems/glazed v0.5.23 h1:L6ua/U8y2zyi3CF49Nj2xbXKgNtBB2drpeCWO5/jeyo=
 github.com/go-go-golems/glazed v0.5.23/go.mod h1:cceXzXliF/CEc8qM/YXhcp9AbBAQpKDMF3+HIlGTDAI=
 github.com/go-go-golems/prompto v0.1.7 h1:A+A84Epo0ZLNU+ZIWlPSLk4WgGFf65Lpm3UTY4mFGAA=

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -3,31 +3,17 @@ package cmds
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 
-	"github.com/ThreeDotsLabs/watermill/message"
-	tea "github.com/charmbracelet/bubbletea"
-	bobatea_chat "github.com/go-go-golems/bobatea/pkg/chat"
 	"github.com/go-go-golems/geppetto/pkg/conversation"
-	"github.com/go-go-golems/geppetto/pkg/events"
-	"github.com/go-go-golems/geppetto/pkg/steps"
-	"github.com/go-go-golems/geppetto/pkg/steps/ai/chat"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	glazedcmds "github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdcontext"
 	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
-	"github.com/go-go-golems/pinocchio/pkg/ui"
-	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/tcnksm/go-input"
-	"golang.org/x/sync/errgroup"
 )
 
 type GeppettoCommandDescription struct {
@@ -97,108 +83,6 @@ func NewGeppettoCommand(
 	return ret, nil
 }
 
-func (g *GeppettoCommand) initializeConversationManager(
-	conversationManager conversation.Manager,
-	helperSettings *cmdlayers.HelpersSettings,
-	ps map[string]interface{},
-) error {
-	if g.SystemPrompt != "" {
-		systemPromptTemplate, err := templating.CreateTemplate("system-prompt").Parse(g.SystemPrompt)
-		if err != nil {
-			return err
-		}
-
-		var systemPromptBuffer strings.Builder
-		err = systemPromptTemplate.Execute(&systemPromptBuffer, ps)
-		if err != nil {
-			return err
-		}
-
-		// TODO(manuel, 2023-12-07) Only do this conditionally, or maybe if the system prompt hasn't been set yet, if you use an agent.
-		conversationManager.AppendMessages(conversation.NewChatMessage(
-			conversation.RoleSystem,
-			systemPromptBuffer.String(),
-		))
-	}
-
-	for _, message_ := range g.Messages {
-		switch content := message_.Content.(type) {
-		case *conversation.ChatMessageContent:
-			messageTemplate, err := templating.CreateTemplate("message").Parse(content.Text)
-			if err != nil {
-				return err
-			}
-
-			var messageBuffer strings.Builder
-			err = messageTemplate.Execute(&messageBuffer, ps)
-			if err != nil {
-				return err
-			}
-			s_ := messageBuffer.String()
-
-			conversationManager.AppendMessages(conversation.NewChatMessage(
-				content.Role, s_, conversation.WithTime(message_.Time)))
-		}
-	}
-
-	// render the prompt
-	if g.Prompt != "" {
-		// TODO(manuel, 2023-02-04) All this could be handle by some prompt renderer kind of thing
-		promptTemplate, err := templating.CreateTemplate("prompt").Parse(g.Prompt)
-		if err != nil {
-			return err
-		}
-
-		// TODO(manuel, 2023-02-04) This is where multisteps would work differently, since
-		// the prompt would be rendered at execution time
-		var promptBuffer strings.Builder
-		err = promptTemplate.Execute(&promptBuffer, ps)
-		if err != nil {
-			return err
-		}
-
-		images := []*conversation.ImageContent{}
-		for _, img := range helperSettings.Images {
-			image, err := conversation.NewImageContentFromFile(img.Path)
-			if err != nil {
-				return err
-			}
-
-			images = append(images, image)
-		}
-		initialPrompt := promptBuffer.String()
-		messageContent := &conversation.ChatMessageContent{
-			Role:   conversation.RoleUser,
-			Text:   initialPrompt,
-			Images: images,
-		}
-		conversationManager.AppendMessages(conversation.NewMessage(messageContent))
-	}
-
-	return nil
-}
-
-func (g *GeppettoCommand) startInitialStep(
-	ctx context.Context,
-	cmdCtx *cmdcontext.CommandContext,
-) (steps.StepResult[*conversation.Message], error) {
-	chatStep, err := cmdCtx.StepFactory.NewStep(chat.WithPublishedTopic(cmdCtx.Router.Publisher, "chat"))
-	if err != nil {
-		return nil, err
-	}
-
-	conversation_ := cmdCtx.ConversationManager.GetConversation()
-	if cmdCtx.Settings.PrintPrompt {
-		fmt.Println(conversation_.GetSinglePrompt())
-		return nil, nil
-	}
-
-	messagesM := steps.Resolve(conversation_)
-	m := steps.Bind[conversation.Conversation, *conversation.Message](ctx, messagesM, chatStep)
-
-	return m, nil
-}
-
 // RunIntoWriter runs the command and writes the output into the given writer.
 func (g *GeppettoCommand) RunIntoWriter(
 	ctx context.Context,
@@ -209,290 +93,48 @@ func (g *GeppettoCommand) RunIntoWriter(
 		return errors.Errorf("Prompt and messages are mutually exclusive")
 	}
 
-	cmdCtx, err := cmdcontext.NewCommandContextFromLayers(parsedLayers, g.StepSettings)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := cmdCtx.Router.Close()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to close pubSub")
-		}
-	}()
-
 	val, present := parsedLayers.Get(layers.DefaultSlug)
 	if !present {
 		return errors.New("could not get default layer")
 	}
 
-	err = g.initializeConversationManager(cmdCtx.ConversationManager, cmdCtx.Settings, val.Parameters.ToMap())
+	settings := &cmdlayers.HelpersSettings{}
+	err := parsedLayers.InitializeStruct(cmdlayers.GeppettoHelpersSlug, settings)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to initialize settings")
 	}
 
-	// load and render the system prompt
-	if cmdCtx.Settings.System != "" {
-		g.SystemPrompt = cmdCtx.Settings.System
+	imagePaths := make([]string, len(settings.Images))
+	for i, img := range settings.Images {
+		imagePaths[i] = img.Path
 	}
 
-	// load and render messages
-	if cmdCtx.Settings.MessageFile != "" {
-		messages_, err := conversation.LoadFromFile(cmdCtx.Settings.MessageFile)
-		if err != nil {
-			return err
-		}
-
-		g.Messages = messages_
-	}
-
-	if cmdCtx.Settings.AppendMessageFile != "" {
-		messages_, err := conversation.LoadFromFile(cmdCtx.Settings.AppendMessageFile)
-		if err != nil {
-			return err
-		}
-		g.Messages = append(g.Messages, messages_...)
-	}
-
-	if cmdCtx.Settings.StartInChat {
-		return g.runChatMode(ctx, cmdCtx)
-	}
-	return g.runNonChatMode(ctx, cmdCtx, w)
-}
-
-func (g *GeppettoCommand) setupPrinter(w io.Writer, settings *cmdlayers.HelpersSettings) func(msg *message.Message) error {
-	if settings.Output != "text" || settings.WithMetadata || settings.FullOutput {
-		return chat.NewStructuredPrinter(w, chat.PrinterOptions{
-			Format:          chat.PrinterFormat(settings.Output),
-			Name:            "",
-			IncludeMetadata: settings.WithMetadata,
-			Full:            settings.FullOutput,
-		})
-	}
-	return chat.StepPrinterFunc("", w)
-}
-
-func chat_(
-	ctx context.Context,
-	step chat.Step,
-	router *events.EventRouter,
-	contextManager conversation.Manager,
-	autoStartBackend bool,
-) error {
-	isOutputTerminal := isatty.IsTerminal(os.Stdout.Fd())
-
-	options := []tea.ProgramOption{
-		tea.WithMouseCellMotion(), // turn on mouse support so we can track the mouse wheel
-	}
-	if !isOutputTerminal {
-		options = append(options, tea.WithOutput(os.Stderr))
-	} else {
-		options = append(options, tea.WithAltScreen())
-	}
-
-	backend := ui.NewStepBackend(step)
-
-	model := bobatea_chat.InitialModel(
-		contextManager,
-		backend,
-		bobatea_chat.WithTitle("pinocchio"),
-		bobatea_chat.WithAutoStartBackend(autoStartBackend),
+	conversationContext, err := cmdcontext.NewConversationContext(
+		cmdcontext.WithSystemPrompt(g.SystemPrompt),
+		cmdcontext.WithMessages(g.Messages),
+		cmdcontext.WithPrompt(g.Prompt),
+		cmdcontext.WithVariables(val.Parameters.ToMap()),
+		cmdcontext.WithImages(imagePaths),
+		cmdcontext.WithAutosaveSettings(cmdcontext.AutosaveSettings{
+			Enabled:  strings.ToLower(settings.Autosave.Enabled) == "yes",
+			Template: settings.Autosave.Template,
+			Path:     settings.Autosave.Path,
+		}),
 	)
+	if err != nil {
+		return err
+	}
 
-	p := tea.NewProgram(
-		model,
-		options...,
+	cmdCtx, err := cmdcontext.NewCommandContextFromLayers(
+		parsedLayers,
+		g.StepSettings,
+		conversationContext.GetManager(),
 	)
-
-	router.AddHandler("ui", "ui", ui.StepChatForwardFunc(p))
-	err := router.RunHandlers(ctx)
 	if err != nil {
 		return err
 	}
+	defer cmdCtx.Close()
 
-	if _, err = p.Run(); err != nil {
-		return err
-	}
-	return nil
-}
+	return cmdCtx.Run(ctx, w)
 
-func (g *GeppettoCommand) runChatMode(ctx context.Context, cmdCtx *cmdcontext.CommandContext) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		defer cancel()
-		return cmdCtx.Router.Run(ctx)
-	})
-
-	eg.Go(func() error {
-		defer cancel()
-
-		cmdCtx.StepFactory.Settings.Chat.Stream = true
-		chatStep, err := cmdCtx.StepFactory.NewStep(chat.WithPublishedTopic(cmdCtx.Router.Publisher, "ui"))
-		if err != nil {
-			return err
-		}
-
-		err = chat_(ctx, chatStep, cmdCtx.Router, cmdCtx.ConversationManager, true)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	return eg.Wait()
-}
-
-func (g *GeppettoCommand) runNonChatMode(
-	ctx context.Context,
-	cmdCtx *cmdcontext.CommandContext,
-	w io.Writer,
-) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	printer := g.setupPrinter(w, cmdCtx.Settings)
-	cmdCtx.Router.AddHandler("chat", "chat", printer)
-
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		defer cancel()
-		return cmdCtx.Router.Run(ctx)
-	})
-
-	eg.Go(func() error {
-		defer cancel()
-
-		m, err := g.startInitialStep(ctx, cmdCtx)
-		if err != nil {
-			return err
-		}
-
-		endedInNewline := false
-		res := m.Return()
-		for _, msg := range res {
-			s, err := msg.Value()
-			if err != nil {
-				return err
-			}
-			cmdCtx.ConversationManager.AppendMessages(s)
-
-			endedInNewline = strings.HasSuffix(s.Content.String(), "\n")
-		}
-
-		if err := g.handleInteractiveContinuation(ctx, cmdCtx, endedInNewline, w); err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	return eg.Wait()
-}
-
-func (g *GeppettoCommand) handleInteractiveContinuation(
-	ctx context.Context,
-	cmdCtx *cmdcontext.CommandContext,
-	endedInNewline bool,
-	_ io.Writer,
-) error {
-	isOutputTerminal := isatty.IsTerminal(os.Stdout.Fd())
-	forceInteractive := cmdCtx.Settings.ForceInteractive
-
-	// Skip interactive mode if non-interactive is set
-	if cmdCtx.Settings.NonInteractive {
-		cmdCtx.Settings.Interactive = false
-	}
-
-	continueInChat := cmdCtx.Settings.Interactive
-	askChat := (isOutputTerminal || forceInteractive) && cmdCtx.Settings.Interactive && !cmdCtx.Settings.NonInteractive
-
-	lengthBeforeChat := len(cmdCtx.ConversationManager.GetConversation())
-
-	if askChat {
-		if !endedInNewline {
-			fmt.Println()
-		}
-
-		var err error
-		continueInChat, err = g.askForChatContinuation(continueInChat)
-		if err != nil {
-			return err
-		}
-	}
-
-	if continueInChat {
-		cmdCtx.StepFactory.Settings.Chat.Stream = true
-		chatStep, err := cmdCtx.StepFactory.NewStep(
-			chat.WithPublishedTopic(cmdCtx.Router.Publisher, "ui"),
-		)
-		if err != nil {
-			return err
-		}
-
-		err = chat_(ctx, chatStep, cmdCtx.Router, cmdCtx.ConversationManager, false)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("\n---\n")
-		for idx, msg := range cmdCtx.ConversationManager.GetConversation() {
-			if idx < lengthBeforeChat {
-				continue
-			}
-			view := msg.Content.View()
-			fmt.Printf("\n%s\n", view)
-		}
-	}
-
-	return nil
-}
-
-func (g *GeppettoCommand) askForChatContinuation(continueInChat bool) (bool, error) {
-	tty_, err := bobatea_chat.OpenTTY()
-	if err != nil {
-		return false, err
-	}
-	defer func() {
-		err := tty_.Close()
-		if err != nil {
-			fmt.Println("Failed to close tty:", err)
-		}
-	}()
-
-	ui := &input.UI{
-		Writer: tty_,
-		Reader: tty_,
-	}
-
-	query := "\nDo you want to continue in chat? [y/n]"
-	answer, err := ui.Ask(query, &input.Options{
-		Default:  "y",
-		Required: true,
-		Loop:     true,
-		ValidateFunc: func(answer string) error {
-			switch answer {
-			case "y", "Y", "n", "N":
-				return nil
-			default:
-				return errors.Errorf("please enter 'y' or 'n'")
-			}
-		},
-	})
-
-	if err != nil {
-		fmt.Println("Failed to get user input:", err)
-		return false, err
-	}
-
-	switch answer {
-	case "y", "Y":
-		continueInChat = true
-
-	case "n", "N":
-		return false, nil
-	}
-	return continueInChat, nil
 }

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -511,22 +511,10 @@ func chat_(
 		return err
 	}
 
-	eg := errgroup.Group{}
-	// eg.Go(func() error {
-	// 	p.Send(bobatea_chat.SubmitMessageMsg{})
-	// 	return nil
-	// })
-
-	eg.Go(func() error {
-
-		if _, err = p.Run(); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	return eg.Wait()
-
+	if _, err = p.Run(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (g *GeppettoCommand) runChatMode(ctx context.Context, cmdCtx *commandContext) error {
@@ -543,7 +531,7 @@ func (g *GeppettoCommand) runChatMode(ctx context.Context, cmdCtx *commandContex
 		defer cancel()
 
 		cmdCtx.stepFactory.Settings.Chat.Stream = true
-		chatStep, err := cmdCtx.stepFactory.NewStep(chat.WithPublishedTopic(cmdCtx.router.Publisher, "chat"))
+		chatStep, err := cmdCtx.stepFactory.NewStep(chat.WithPublishedTopic(cmdCtx.router.Publisher, "ui"))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmds/cmdcontext/command-context.go
+++ b/pkg/cmds/cmdcontext/command-context.go
@@ -1,13 +1,28 @@
 package cmdcontext
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	tea "github.com/charmbracelet/bubbletea"
+	bobatea_chat "github.com/go-go-golems/bobatea/pkg/chat"
 	"github.com/go-go-golems/geppetto/pkg/conversation"
 	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/steps"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/chat"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
+	"github.com/go-go-golems/pinocchio/pkg/ui"
+	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
+	"github.com/tcnksm/go-input"
+	"golang.org/x/sync/errgroup"
 )
 
 type CommandContext struct {
@@ -19,36 +34,31 @@ type CommandContext struct {
 
 type CommandContextOption func(*CommandContext) error
 
-func WithCommandContextRouter(router *events.EventRouter) CommandContextOption {
+func WithRouter(router *events.EventRouter) CommandContextOption {
 	return func(c *CommandContext) error {
 		c.Router = router
 		return nil
 	}
 }
 
-func WithCommandContextConversationManager(manager conversation.Manager) CommandContextOption {
-	return func(c *CommandContext) error {
-		c.ConversationManager = manager
-		return nil
-	}
-}
-
-func WithCommandContextStepFactory(factory *ai.StandardStepFactory) CommandContextOption {
+func WithStepFactory(factory *ai.StandardStepFactory) CommandContextOption {
 	return func(c *CommandContext) error {
 		c.StepFactory = factory
 		return nil
 	}
 }
 
-func WithCommandContextSettings(settings *cmdlayers.HelpersSettings) CommandContextOption {
+func WithSettings(settings *cmdlayers.HelpersSettings) CommandContextOption {
 	return func(c *CommandContext) error {
 		c.Settings = settings
 		return nil
 	}
 }
 
-func NewCommandContext(options ...CommandContextOption) (*CommandContext, error) {
-	ctx := &CommandContext{}
+func NewCommandContext(conversationManager conversation.Manager, options ...CommandContextOption) (*CommandContext, error) {
+	ctx := &CommandContext{
+		ConversationManager: conversationManager,
+	}
 	for _, opt := range options {
 		if err := opt(ctx); err != nil {
 			return nil, err
@@ -57,20 +67,25 @@ func NewCommandContext(options ...CommandContextOption) (*CommandContext, error)
 	return ctx, nil
 }
 
-func NewCommandContextFromLayers(parsedLayers *layers.ParsedLayers, stepSettings *settings.StepSettings) (*CommandContext, error) {
+func NewCommandContextFromLayers(
+	parsedLayers *layers.ParsedLayers,
+	initialStepSettings *settings.StepSettings,
+	conversationManager conversation.Manager,
+	options ...CommandContextOption,
+) (*CommandContext, error) {
 	settings := &cmdlayers.HelpersSettings{}
 	err := parsedLayers.InitializeStruct(cmdlayers.GeppettoHelpersSlug, settings)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize settings")
 	}
 
-	err = stepSettings.UpdateFromParsedLayers(parsedLayers)
+	err = initialStepSettings.UpdateFromParsedLayers(parsedLayers)
 	if err != nil {
 		return nil, err
 	}
 
 	stepFactory := &ai.StandardStepFactory{
-		Settings: stepSettings,
+		Settings: initialStepSettings,
 	}
 
 	router, err := events.NewEventRouter()
@@ -78,18 +93,240 @@ func NewCommandContextFromLayers(parsedLayers *layers.ParsedLayers, stepSettings
 		return nil, err
 	}
 
-	conversationManager := conversation.NewManager(
-		conversation.WithAutosave(
-			settings.Autosave.Enabled,
-			settings.Autosave.Template,
-			settings.Autosave.Path,
-		),
+	options_ := append(options,
+		WithRouter(router),
+		WithStepFactory(stepFactory),
+		WithSettings(settings),
 	)
 
-	return NewCommandContext(
-		WithCommandContextRouter(router),
-		WithCommandContextConversationManager(conversationManager),
-		WithCommandContextStepFactory(stepFactory),
-		WithCommandContextSettings(settings),
+	return NewCommandContext(conversationManager, options_...)
+}
+
+func (c *CommandContext) Close() error {
+	if c.Router != nil {
+		return c.Router.Close()
+	}
+	return nil
+}
+
+func (c *CommandContext) StartInitialStep(
+	ctx context.Context,
+) (steps.StepResult[*conversation.Message], error) {
+	chatStep, err := c.StepFactory.NewStep(chat.WithPublishedTopic(c.Router.Publisher, "chat"))
+	if err != nil {
+		return nil, err
+	}
+
+	conversation_ := c.ConversationManager.GetConversation()
+	if c.Settings.PrintPrompt {
+		fmt.Println(conversation_.GetSinglePrompt())
+		return nil, nil
+	}
+
+	messagesM := steps.Resolve(conversation_)
+	m := steps.Bind[conversation.Conversation, *conversation.Message](ctx, messagesM, chatStep)
+
+	return m, nil
+}
+
+func (c *CommandContext) handleChat(
+	ctx context.Context,
+	autoStartBackend bool,
+) error {
+	isOutputTerminal := isatty.IsTerminal(os.Stdout.Fd())
+
+	options := []tea.ProgramOption{
+		tea.WithMouseCellMotion(),
+	}
+	if !isOutputTerminal {
+		options = append(options, tea.WithOutput(os.Stderr))
+	} else {
+		options = append(options, tea.WithAltScreen())
+	}
+
+	c.StepFactory.Settings.Chat.Stream = true
+	chatStep, err := c.StepFactory.NewStep(chat.WithPublishedTopic(c.Router.Publisher, "ui"))
+	if err != nil {
+		return err
+	}
+
+	backend := ui.NewStepBackend(chatStep)
+
+	model := bobatea_chat.InitialModel(
+		c.ConversationManager,
+		backend,
+		bobatea_chat.WithTitle("pinocchio"),
+		bobatea_chat.WithAutoStartBackend(autoStartBackend),
 	)
+
+	p := tea.NewProgram(
+		model,
+		options...,
+	)
+
+	c.Router.AddHandler("ui", "ui", ui.StepChatForwardFunc(p))
+	err = c.Router.RunHandlers(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err = p.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CommandContext) handleInteractiveContinuation(
+	ctx context.Context,
+	endedInNewline bool,
+) error {
+	isOutputTerminal := isatty.IsTerminal(os.Stdout.Fd())
+	forceInteractive := c.Settings.ForceInteractive
+
+	if c.Settings.NonInteractive {
+		c.Settings.Interactive = false
+	}
+
+	continueInChat := c.Settings.Interactive
+	askChat := (isOutputTerminal || forceInteractive) && c.Settings.Interactive && !c.Settings.NonInteractive
+
+	lengthBeforeChat := len(c.ConversationManager.GetConversation())
+
+	if askChat {
+		var err error
+		continueInChat, err = c.askForChatContinuation(continueInChat)
+		if err != nil {
+			return err
+		}
+	}
+
+	if continueInChat {
+		c.StepFactory.Settings.Chat.Stream = true
+		err := c.handleChat(ctx, false)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\n---\n")
+		for idx, msg := range c.ConversationManager.GetConversation() {
+			if idx < lengthBeforeChat {
+				continue
+			}
+			view := msg.Content.View()
+			fmt.Printf("\n%s\n", view)
+		}
+	}
+
+	return nil
+}
+
+func (c *CommandContext) askForChatContinuation(continueInChat bool) (bool, error) {
+	tty_, err := bobatea_chat.OpenTTY()
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		err := tty_.Close()
+		if err != nil {
+			fmt.Println("Failed to close tty:", err)
+		}
+	}()
+
+	ui := &input.UI{
+		Writer: tty_,
+		Reader: tty_,
+	}
+
+	query := "\nDo you want to continue in chat? [y/n]"
+	answer, err := ui.Ask(query, &input.Options{
+		Default:  "y",
+		Required: true,
+		Loop:     true,
+		ValidateFunc: func(answer string) error {
+			switch answer {
+			case "y", "Y", "n", "N":
+				return nil
+			default:
+				return errors.Errorf("please enter 'y' or 'n'")
+			}
+		},
+	})
+
+	if err != nil {
+		fmt.Println("Failed to get user input:", err)
+		return false, err
+	}
+
+	switch answer {
+	case "y", "Y":
+		continueInChat = true
+	case "n", "N":
+		return false, nil
+	}
+	return continueInChat, nil
+}
+
+func (c *CommandContext) setupPrinter(w io.Writer) func(msg *message.Message) error {
+	if c.Settings.Output != "text" || c.Settings.WithMetadata || c.Settings.FullOutput {
+		return chat.NewStructuredPrinter(w, chat.PrinterOptions{
+			Format:          chat.PrinterFormat(c.Settings.Output),
+			Name:            "",
+			IncludeMetadata: c.Settings.WithMetadata,
+			Full:            c.Settings.FullOutput,
+		})
+	}
+	return chat.StepPrinterFunc("", w)
+}
+
+func (c *CommandContext) handleNonChatMode(
+	ctx context.Context,
+	w io.Writer,
+) error {
+	printer := c.setupPrinter(w)
+	c.Router.AddHandler("chat", "chat", printer)
+	err := c.Router.RunHandlers(ctx)
+	if err != nil {
+		return err
+	}
+
+	m, err := c.StartInitialStep(ctx)
+	if err != nil {
+		return err
+	}
+
+	endedInNewline := false
+	res := m.Return()
+	for _, msg := range res {
+		s, err := msg.Value()
+		if err != nil {
+			return err
+		}
+		c.ConversationManager.AppendMessages(s)
+
+		endedInNewline = strings.HasSuffix(s.Content.String(), "\n")
+	}
+
+	if err := c.handleInteractiveContinuation(ctx, endedInNewline); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CommandContext) Run(ctx context.Context, w io.Writer) error {
+	eg := errgroup.Group{}
+
+	eg.Go(func() error {
+		return c.Router.Run(ctx)
+	})
+
+	eg.Go(func() error {
+		<-c.Router.Running()
+		if c.Settings.StartInChat {
+			return c.handleChat(ctx, true)
+		}
+		return c.handleNonChatMode(ctx, w)
+	})
+
+	return eg.Wait()
 }

--- a/pkg/cmds/cmdcontext/command-context.go
+++ b/pkg/cmds/cmdcontext/command-context.go
@@ -316,11 +316,16 @@ func (c *CommandContext) handleNonChatMode(
 func (c *CommandContext) Run(ctx context.Context, w io.Writer) error {
 	eg := errgroup.Group{}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	eg.Go(func() error {
+		defer cancel()
 		return c.Router.Run(ctx)
 	})
 
 	eg.Go(func() error {
+		defer cancel()
 		<-c.Router.Running()
 		if c.Settings.StartInChat {
 			return c.handleChat(ctx, true)

--- a/pkg/cmds/cmdcontext/command-context.go
+++ b/pkg/cmds/cmdcontext/command-context.go
@@ -1,0 +1,95 @@
+package cmdcontext
+
+import (
+	"github.com/go-go-golems/geppetto/pkg/conversation"
+	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
+	"github.com/pkg/errors"
+)
+
+type CommandContext struct {
+	Router              *events.EventRouter
+	ConversationManager conversation.Manager
+	StepFactory         *ai.StandardStepFactory
+	Settings            *cmdlayers.HelpersSettings
+}
+
+type CommandContextOption func(*CommandContext) error
+
+func WithCommandContextRouter(router *events.EventRouter) CommandContextOption {
+	return func(c *CommandContext) error {
+		c.Router = router
+		return nil
+	}
+}
+
+func WithCommandContextConversationManager(manager conversation.Manager) CommandContextOption {
+	return func(c *CommandContext) error {
+		c.ConversationManager = manager
+		return nil
+	}
+}
+
+func WithCommandContextStepFactory(factory *ai.StandardStepFactory) CommandContextOption {
+	return func(c *CommandContext) error {
+		c.StepFactory = factory
+		return nil
+	}
+}
+
+func WithCommandContextSettings(settings *cmdlayers.HelpersSettings) CommandContextOption {
+	return func(c *CommandContext) error {
+		c.Settings = settings
+		return nil
+	}
+}
+
+func NewCommandContext(options ...CommandContextOption) (*CommandContext, error) {
+	ctx := &CommandContext{}
+	for _, opt := range options {
+		if err := opt(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return ctx, nil
+}
+
+func NewCommandContextFromLayers(parsedLayers *layers.ParsedLayers, stepSettings *settings.StepSettings) (*CommandContext, error) {
+	settings := &cmdlayers.HelpersSettings{}
+	err := parsedLayers.InitializeStruct(cmdlayers.GeppettoHelpersSlug, settings)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize settings")
+	}
+
+	err = stepSettings.UpdateFromParsedLayers(parsedLayers)
+	if err != nil {
+		return nil, err
+	}
+
+	stepFactory := &ai.StandardStepFactory{
+		Settings: stepSettings,
+	}
+
+	router, err := events.NewEventRouter()
+	if err != nil {
+		return nil, err
+	}
+
+	conversationManager := conversation.NewManager(
+		conversation.WithAutosave(
+			settings.Autosave.Enabled,
+			settings.Autosave.Template,
+			settings.Autosave.Path,
+		),
+	)
+
+	return NewCommandContext(
+		WithCommandContextRouter(router),
+		WithCommandContextConversationManager(conversationManager),
+		WithCommandContextStepFactory(stepFactory),
+		WithCommandContextSettings(settings),
+	)
+}

--- a/pkg/cmds/cmdcontext/conversation-context.go
+++ b/pkg/cmds/cmdcontext/conversation-context.go
@@ -1,0 +1,192 @@
+package cmdcontext
+
+import (
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/conversation"
+	"github.com/go-go-golems/glazed/pkg/helpers/templating"
+	"github.com/pkg/errors"
+)
+
+type ConversationContext struct {
+	SystemPrompt string
+	Messages     []*conversation.Message
+	Prompt       string
+	Variables    map[string]interface{}
+	Images       []string
+
+	manager conversation.Manager
+}
+
+type ConversationContextOption func(*ConversationContext) error
+
+func WithSystemPrompt(systemPrompt string) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		c.SystemPrompt = systemPrompt
+		return nil
+	}
+}
+
+func WithMessages(messages []*conversation.Message) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		c.Messages = messages
+		return nil
+	}
+}
+
+func WithPrompt(prompt string) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		c.Prompt = prompt
+		return nil
+	}
+}
+
+func WithVariables(variables map[string]interface{}) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		c.Variables = variables
+		return nil
+	}
+}
+
+func WithImages(images []string) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		c.Images = images
+		return nil
+	}
+}
+
+type AutosaveSettings struct {
+	Enabled  bool
+	Template string
+	Path     string
+}
+
+func WithAutosaveSettings(settings AutosaveSettings) ConversationContextOption {
+	return func(c *ConversationContext) error {
+		enabled := "no"
+		if settings.Enabled {
+			enabled = "yes"
+		}
+		c.manager = conversation.NewManager(
+			conversation.WithAutosave(
+				enabled,
+				settings.Template,
+				settings.Path,
+			),
+		)
+		return nil
+	}
+}
+
+func NewConversationContext(options ...ConversationContextOption) (*ConversationContext, error) {
+	ctx := &ConversationContext{
+		Variables: make(map[string]interface{}),
+		manager:   conversation.NewManager(),
+	}
+
+	for _, opt := range options {
+		if err := opt(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	err := ctx.initialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+func (c *ConversationContext) initialize() error {
+	if c.SystemPrompt != "" {
+		systemPromptTemplate, err := templating.CreateTemplate("system-prompt").Parse(c.SystemPrompt)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse system prompt template")
+		}
+
+		var systemPromptBuffer strings.Builder
+		err = systemPromptTemplate.Execute(&systemPromptBuffer, c.Variables)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute system prompt template")
+		}
+
+		c.manager.AppendMessages(conversation.NewChatMessage(
+			conversation.RoleSystem,
+			systemPromptBuffer.String(),
+		))
+	}
+
+	for _, message_ := range c.Messages {
+		switch content := message_.Content.(type) {
+		case *conversation.ChatMessageContent:
+			messageTemplate, err := templating.CreateTemplate("message").Parse(content.Text)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse message template")
+			}
+
+			var messageBuffer strings.Builder
+			err = messageTemplate.Execute(&messageBuffer, c.Variables)
+			if err != nil {
+				return errors.Wrap(err, "failed to execute message template")
+			}
+			s_ := messageBuffer.String()
+
+			c.manager.AppendMessages(conversation.NewChatMessage(
+				content.Role, s_, conversation.WithTime(message_.Time)))
+		}
+	}
+
+	if c.Prompt != "" {
+		promptTemplate, err := templating.CreateTemplate("prompt").Parse(c.Prompt)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse prompt template")
+		}
+
+		var promptBuffer strings.Builder
+		err = promptTemplate.Execute(&promptBuffer, c.Variables)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute prompt template")
+		}
+
+		images := []*conversation.ImageContent{}
+		for _, imagePath := range c.Images {
+			image, err := conversation.NewImageContentFromFile(imagePath)
+			if err != nil {
+				return errors.Wrap(err, "failed to create image content")
+			}
+			images = append(images, image)
+		}
+
+		messageContent := &conversation.ChatMessageContent{
+			Role:   conversation.RoleUser,
+			Text:   promptBuffer.String(),
+			Images: images,
+		}
+		c.manager.AppendMessages(conversation.NewMessage(messageContent))
+	}
+
+	return nil
+}
+
+func (c *ConversationContext) GetManager() conversation.Manager {
+	return c.manager
+}
+
+func (c *ConversationContext) AppendImageToPrompt(imagePath string) error {
+	if c.Prompt == "" {
+		return errors.New("cannot append image to empty prompt")
+	}
+
+	image, err := conversation.NewImageContentFromFile(imagePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create image content")
+	}
+
+	lastMessage := c.manager.GetConversation()[len(c.manager.GetConversation())-1]
+	if content, ok := lastMessage.Content.(*conversation.ChatMessageContent); ok {
+		content.Images = append(content.Images, image)
+	}
+
+	return nil
+}

--- a/pkg/cmds/cmdlayers/helpers.go
+++ b/pkg/cmds/cmdlayers/helpers.go
@@ -1,0 +1,121 @@
+package cmdlayers
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+)
+
+type AutosaveSettings struct {
+	Path     string `glazed.parameter:"path"`
+	Template string `glazed.parameter:"template"`
+	Enabled  string `glazed.parameter:"enabled"`
+}
+
+type HelpersSettings struct {
+	PrintPrompt       bool                   `glazed.parameter:"print-prompt"`
+	System            string                 `glazed.parameter:"system"`
+	AppendMessageFile string                 `glazed.parameter:"append-message-file"`
+	MessageFile       string                 `glazed.parameter:"message-file"`
+	StartInChat       bool                   `glazed.parameter:"chat"`
+	Interactive       bool                   `glazed.parameter:"interactive"`
+	ForceInteractive  bool                   `glazed.parameter:"force-interactive"`
+	Images            []*parameters.FileData `glazed.parameter:"images"`
+	Autosave          *AutosaveSettings      `glazed.parameter:"autosave,from_json"`
+	NonInteractive    bool                   `glazed.parameter:"non-interactive"`
+	Output            string                 `glazed.parameter:"output"`
+	WithMetadata      bool                   `glazed.parameter:"with-metadata"`
+	FullOutput        bool                   `glazed.parameter:"full-output"`
+}
+
+const GeppettoHelpersSlug = "geppetto-helpers"
+
+func NewHelpersParameterLayer() (layers.ParameterLayer, error) {
+	defaultHistoryPath := filepath.Join(os.Getenv("HOME"), ".pinocchio", "history")
+
+	return layers.NewParameterLayer(GeppettoHelpersSlug, "Geppetto helpers",
+		layers.WithParameterDefinitions(
+			parameters.NewParameterDefinition(
+				"print-prompt",
+				parameters.ParameterTypeBool,
+				parameters.WithDefault(false),
+				parameters.WithHelp("Print the prompt"),
+			),
+			parameters.NewParameterDefinition(
+				"system",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("System message"),
+			),
+			parameters.NewParameterDefinition(
+				"append-message-file",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("File containing messages (json or yaml, list of objects with fields text, time, role) to be appended to the already present list of messages"),
+			),
+			parameters.NewParameterDefinition(
+				"message-file",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("File containing messages (json or yaml, list of objects with fields text, time, role)"),
+			),
+			parameters.NewParameterDefinition(
+				"interactive",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Ask for chat continuation after inference"),
+				parameters.WithDefault(true),
+			),
+			parameters.NewParameterDefinition(
+				"chat",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Start in chat mode"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"force-interactive",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Always enter interactive mode, even with non-tty stdout"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"images",
+				parameters.ParameterTypeFileList,
+				parameters.WithHelp("Images to display"),
+			),
+			parameters.NewParameterDefinition(
+				"autosave",
+				parameters.ParameterTypeKeyValue,
+				parameters.WithHelp("Autosave configuration"),
+				parameters.WithDefault(map[string]interface{}{
+					"path":     defaultHistoryPath,
+					"template": "",
+					"enabled":  "no",
+				}),
+			),
+			parameters.NewParameterDefinition(
+				"non-interactive",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Skip interactive chat mode entirely"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"output",
+				parameters.ParameterTypeChoice,
+				parameters.WithHelp("Output format (text, json, yaml)"),
+				parameters.WithDefault("text"),
+				parameters.WithChoices("text", "json", "yaml"),
+			),
+			parameters.NewParameterDefinition(
+				"with-metadata",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Include event metadata in output"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"full-output",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Print all available metadata in output"),
+				parameters.WithDefault(false),
+			),
+		),
+	)
+}

--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/middlewares"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +22,7 @@ func BuildCobraCommandWithGeppettoMiddlewares(
 ) (*cobra.Command, error) {
 	options_ := append([]cli.CobraParserOption{
 		cli.WithCobraMiddlewaresFunc(GetCobraCommandGeppettoMiddlewares),
-		cli.WithCobraShortHelpLayers(layers.DefaultSlug, GeppettoHelpersSlug),
+		cli.WithCobraShortHelpLayers(layers.DefaultSlug, cmdlayers.GeppettoHelpersSlug),
 	}, options...)
 
 	return cli.BuildCobraCommandFromCommand(cmd, options_...)
@@ -83,7 +84,7 @@ func GetCobraCommandGeppettoMiddlewares(
 				settings.AiClientSlug,
 				openai.OpenAiChatSlug,
 				claude.ClaudeChatSlug,
-				GeppettoHelpersSlug,
+				cmdlayers.GeppettoHelpersSlug,
 			},
 			middlewares.GatherFlagsFromViper(parameters.WithParseStepSource("viper")),
 		),

--- a/pkg/cmds/loader.go
+++ b/pkg/cmds/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/loaders"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -140,7 +141,7 @@ func CreateGeppettoLayers(stepSettings *settings.StepSettings) ([]layers.Paramet
 	// TODO(manuel, 2024-01-17) Disable not fully function ollama layer for now
 	_ = ollamaParameterLayer
 
-	helpersLayer, err := NewHelpersParameterLayer()
+	helpersLayer, err := cmdlayers.NewHelpersParameterLayer()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ui/backend.go
+++ b/pkg/ui/backend.go
@@ -39,8 +39,8 @@ func (s *StepBackend) Start(ctx context.Context, msgs []*conversation.Message) (
 			return nil
 		}
 		stepChannel := s.stepResult.GetChannel()
-		// TODO(manuel, 2023-12-09) stream answers into the context manager
 		for range stepChannel {
+			// just wait for the step to finish, progress is handled through the published events
 		}
 
 		s.stepResult = nil

--- a/pkg/ui/backend.go
+++ b/pkg/ui/backend.go
@@ -16,8 +16,8 @@ import (
 )
 
 type StepBackend struct {
-	stepFactory chat.Step
-	stepResult  steps.StepResult[*conversation.Message]
+	step       chat.Step
+	stepResult steps.StepResult[*conversation.Message]
 }
 
 var _ boba_chat.Backend = &StepBackend{}
@@ -27,7 +27,7 @@ func (s *StepBackend) Start(ctx context.Context, msgs []*conversation.Message) (
 		return nil, errors.New("Step is already running")
 	}
 
-	stepResult, err := s.stepFactory.Start(ctx, msgs)
+	stepResult, err := s.step.Start(ctx, msgs)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (s *StepBackend) Start(ctx context.Context, msgs []*conversation.Message) (
 
 func NewStepBackend(step chat.Step) *StepBackend {
 	return &StepBackend{
-		stepFactory: step,
+		step: step,
 	}
 }
 

--- a/ttmp/2024-12-30/changelog.md
+++ b/ttmp/2024-12-30/changelog.md
@@ -25,3 +25,20 @@ Updated the structured printer to provide a more focused view of important metad
 - Added --full-output flag to access complete metadata when needed
 - Improved start event to show input token usage
 - Structured final event to show token usage and stop reason clearly 
+
+# Refactor Settings Initialization in GeppettoCommand
+
+Simplified the settings initialization flow by moving it into the setupInfrastructure method to reduce code complexity and improve maintainability.
+
+- Removed separate initializeSettings method
+- Integrated settings initialization directly into setupInfrastructure
+- Updated RunIntoWriter to use settings from commandContext 
+
+# Extract CommandContext into Standalone Type
+
+Extracted commandContext into a standalone type with a builder pattern to improve modularity and reusability.
+
+- Created CommandContextOption for flexible context configuration
+- Added WithXXX option functions for each context field
+- Implemented NewCommandContext and NewCommandContextFromLayers builders
+- Removed dependency on GeppettoCommand for context creation 

--- a/ttmp/2024-12-30/changelog.md
+++ b/ttmp/2024-12-30/changelog.md
@@ -42,3 +42,23 @@ Extracted commandContext into a standalone type with a builder pattern to improv
 - Added WithXXX option functions for each context field
 - Implemented NewCommandContext and NewCommandContextFromLayers builders
 - Removed dependency on GeppettoCommand for context creation 
+
+# Refactor Command Context
+
+Moved conversation management, step execution, and chat handling from GeppettoCommand to CommandContext for better separation of concerns and reusability.
+
+- Moved `initializeConversationManager` to `CommandContext`
+- Moved step execution logic to `CommandContext`
+- Moved chat and UI handling to `CommandContext`
+- Simplified `GeppettoCommand` to focus on configuration
+- Added proper cleanup with `Close` method in `CommandContext` 
+
+# Extract ConversationContext into Standalone Type
+
+Created a new ConversationContext type to handle conversation initialization and management, improving modularity and separation of concerns.
+
+- Created ConversationContext with builder pattern for flexible configuration
+- Added support for system prompts, messages, variables, and images
+- Moved template rendering and conversation initialization logic
+- Added proper autosave settings handling
+- Simplified CommandContext by delegating conversation management 


### PR DESCRIPTION
Major refactoring of the chat handling code to improve modularity and add the ability to 
start directly in chat mode.

Key changes:
- Extract chat handling logic into dedicated CommandContext type
- Create ConversationContext to manage conversation state and initialization
- Move helper settings into separate package
- Add --chat flag to start directly in chat mode without initial prompt

Breaking changes:
- Renamed --automatically-continue-in-chat flag to just --chat
- Changed behavior of --chat flag to start directly in chat mode
- System prompt YAML key changed from system_prompt to system-prompt

The refactoring improves code organization and maintainability while adding the 
ability to start directly in chat mode without requiring an initial prompt 
interaction.