### PR TITLE
Add example command and fix print-prompt behavior

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,18 @@
             }
         },
         {
+            "name": "Pinocchio Test print-prompt",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/pinocchio",
+            "args": ["examples", "test", "--print-prompt"],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PINOCCHIO_PROFILE": "4o-mini"
+            }
+        },
+        {
             "name": "Pinocchio Test output yaml o4-mini",
             "type": "go",
             "request": "launch",

--- a/cmd/examples/simple-chat-step/main.go
+++ b/cmd/examples/simple-chat-step/main.go
@@ -67,7 +67,7 @@ func (c *TestCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.Pa
 		return errors.Wrap(err, "failed to initialize settings")
 	}
 
-	geppettoParsedLayers, err := helpers.ParseGeppettoLayersFromProfiles(c.pinocchioCmd, helpers.WithProfile(s.PinocchioProfile))
+	geppettoParsedLayers, err := helpers.ParseGeppettoLayers(c.pinocchioCmd, helpers.WithProfile(s.PinocchioProfile))
 	if err != nil {
 		return err
 	}

--- a/cmd/examples/simple-chat-step/main.go
+++ b/cmd/examples/simple-chat-step/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io"
+	"os"
+
+	clay "github.com/go-go-golems/clay/pkg"
+	"github.com/go-go-golems/geppetto/pkg/conversation"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/claude"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/middlewares"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	pinocchio_cmds "github.com/go-go-golems/pinocchio/pkg/cmds"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed test.yaml
+var promptsFS embed.FS
+
+var rootCmd = &cobra.Command{
+	Use:   "simple-chat-step",
+	Short: "A simple chat step",
+}
+
+type TestCommand struct {
+	*cmds.CommandDescription
+	pinocchioCmd *pinocchio_cmds.GeppettoCommand
+}
+
+type TestCommandSettings struct {
+	PinocchioProfile string `glazed.parameter:"pinocchio-profile"`
+	Debug            bool   `glazed.parameter:"debug"`
+}
+
+func NewTestCommand(cmd *pinocchio_cmds.GeppettoCommand) *TestCommand {
+	return &TestCommand{
+		CommandDescription: cmds.NewCommandDescription("test2",
+			cmds.WithShort("Test prompt"),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition("pinocchio-profile",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Pinocchio profile"),
+					parameters.WithDefault("default"),
+				),
+				parameters.NewParameterDefinition("debug",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Debug mode"),
+					parameters.WithDefault(false),
+				),
+			),
+		),
+		pinocchioCmd: cmd,
+	}
+}
+
+func (c *TestCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &TestCommandSettings{}
+	err := parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize settings")
+	}
+
+	xdgConfigPath, err := os.UserConfigDir()
+	if err != nil {
+		return err
+	}
+	defaultProfileFile := fmt.Sprintf("%s/pinocchio/profiles.yaml", xdgConfigPath)
+	middlewares_ := []middlewares.Middleware{}
+	middlewares_ = append(middlewares_,
+		middlewares.GatherFlagsFromProfiles(
+			defaultProfileFile,
+			defaultProfileFile,
+			s.PinocchioProfile,
+			parameters.WithParseStepSource("profiles"),
+			parameters.WithParseStepMetadata(map[string]interface{}{
+				"profileFile": defaultProfileFile,
+				"profile":     s.PinocchioProfile,
+			}),
+		),
+	)
+	middlewares_ = append(middlewares_,
+		middlewares.WrapWithWhitelistedLayers(
+			[]string{
+				settings.AiChatSlug,
+				settings.AiClientSlug,
+				openai.OpenAiChatSlug,
+				claude.ClaudeChatSlug,
+				cmdlayers.GeppettoHelpersSlug,
+			},
+			middlewares.GatherFlagsFromViper(parameters.WithParseStepSource("viper")),
+		),
+		middlewares.SetFromDefaults(parameters.WithParseStepSource("defaults")),
+	)
+
+	geppettoParsedLayers := layers.NewParsedLayers()
+	err = middlewares.ExecuteMiddlewares(c.pinocchioCmd.Description().Layers, geppettoParsedLayers, middlewares_...)
+	if err != nil {
+		return err
+	}
+
+	if s.Debug {
+		// marshal geppettoParsedLayer to yaml and print it
+		b_, err := yaml.Marshal(geppettoParsedLayers)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b_))
+		return nil
+	}
+
+	cmdCtx, _, err := c.pinocchioCmd.CreateCommandContextFromParsedLayers(geppettoParsedLayers)
+	if err != nil {
+		return err
+	}
+
+	printer := cmdCtx.SetupPrinter(os.Stdout)
+	cmdCtx.Router.AddHandler("chat", "chat", printer)
+
+	messages, err := cmdCtx.RunStepBlocking(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("\n--------------------------------")
+	fmt.Println()
+
+	for _, msg := range messages {
+		if chatMsg, ok := msg.Content.(*conversation.ChatMessageContent); ok {
+			fmt.Printf("%s: %s\n", chatMsg.Role, chatMsg.Text)
+		} else {
+			fmt.Printf("%s: %s\n", msg.Content.ContentType(), msg.Content.String())
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	err := clay.InitViper("pinocchio", rootCmd)
+	cobra.CheckErr(err)
+	err = clay.InitLogger()
+	cobra.CheckErr(err)
+
+	// load command from yaml
+	loader := &pinocchio_cmds.GeppettoCommandLoader{}
+	commands, err := loader.LoadCommands(promptsFS, "test.yaml", nil, nil)
+	cobra.CheckErr(err)
+
+	// Register the command as a normal cobra command and let it parse its step settings by itself
+	cli.AddCommandsToRootCommand(rootCmd, commands, nil,
+		cli.WithCobraMiddlewaresFunc(pinocchio_cmds.GetCobraCommandGeppettoMiddlewares),
+		cli.WithCobraShortHelpLayers(layers.DefaultSlug, cmdlayers.GeppettoHelpersSlug),
+	)
+
+	if len(rootCmd.Commands()) == 1 {
+		cmd := commands[0].(*pinocchio_cmds.GeppettoCommand)
+		testCmd := NewTestCommand(cmd)
+		command, err := cli.BuildCobraCommandFromWriterCommand(testCmd)
+		cobra.CheckErr(err)
+		rootCmd.AddCommand(command)
+	}
+
+	cobra.CheckErr(rootCmd.Execute())
+}

--- a/cmd/examples/simple-chat-step/test.yaml
+++ b/cmd/examples/simple-chat-step/test.yaml
@@ -1,0 +1,19 @@
+name: test
+short: Test prompt
+long: A small test prompt
+flags:
+  - name: pretend
+    type: string
+    default: "scientist"
+    help: Pretend to be a ??
+  - name: what
+    type: string
+    default: "age"
+    help: What am I asking about?
+  - name: of
+    type: string
+    default: "you"
+    help: Of what am I asking?
+system-prompt: You are a LLM.
+prompt: |
+  Pretend you are a {{.pretend}}. What is the {{.what}} of {{.of}}? 2 words.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/go-go-golems/clay v0.1.20
 	github.com/go-go-golems/geppetto v0.4.28
 	github.com/go-go-golems/glazed v0.5.23
-	github.com/go-go-golems/prompto v0.1.7
+	github.com/go-go-golems/prompto v0.1.8
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.12.0
@@ -43,6 +43,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/a-h/templ v0.2.793 // indirect
 	github.com/adrg/frontmatter v0.2.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbav
 github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/ThreeDotsLabs/watermill v1.3.7 h1:NV0PSTmuACVEOV4dMxRnmGXrmbz8U83LENOvpHekN7o=
 github.com/ThreeDotsLabs/watermill v1.3.7/go.mod h1:lBnrLbxOjeMRgcJbv+UiZr8Ylz8RkJ4m6i/VN/Nk+to=
+github.com/a-h/templ v0.2.793 h1:Io+/ocnfGWYO4VHdR0zBbf39PQlnzVCVVD+wEEs6/qY=
+github.com/a-h/templ v0.2.793/go.mod h1:lq48JXoUvuQrU0VThrK31yFwdRjTCnIE5bcPCM9IP1w=
 github.com/adrg/frontmatter v0.2.0 h1:/DgnNe82o03riBd1S+ZDjd43wAmC6W35q67NHeLkPd4=
 github.com/adrg/frontmatter v0.2.0/go.mod h1:93rQCj3z3ZlwyxxpQioRKC1wDLto4aXHrbqIsnH9wmE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
@@ -99,8 +101,8 @@ github.com/go-go-golems/geppetto v0.4.28 h1:0KUCd5DeP4KzNUUZ/5hmMD2kSFRYCr+hN0kl
 github.com/go-go-golems/geppetto v0.4.28/go.mod h1:cAv9cYbPNrH9gdqmoefC93p//E7xgqQtDXd0KSmHzS0=
 github.com/go-go-golems/glazed v0.5.23 h1:L6ua/U8y2zyi3CF49Nj2xbXKgNtBB2drpeCWO5/jeyo=
 github.com/go-go-golems/glazed v0.5.23/go.mod h1:cceXzXliF/CEc8qM/YXhcp9AbBAQpKDMF3+HIlGTDAI=
-github.com/go-go-golems/prompto v0.1.7 h1:A+A84Epo0ZLNU+ZIWlPSLk4WgGFf65Lpm3UTY4mFGAA=
-github.com/go-go-golems/prompto v0.1.7/go.mod h1:C/v+c5etuRYZ32oZZzTJqV64k2ORCxH4DAHFBtYdMDk=
+github.com/go-go-golems/prompto v0.1.8 h1:SX2gYo2m3RDvx10/S9j5FVpHCAorOmd6DVG8+XuBiN0=
+github.com/go-go-golems/prompto v0.1.8/go.mod h1:4fzGx5hGExYx3vzXfY63EPKE2WWKs5VGgze9GlWIORI=
 github.com/go-go-golems/sqleton v0.2.4 h1:qsgX0RxBXdjOC/+zmRrVvlsbBT8HCM2otLh/bV/f5uU=
 github.com/go-go-golems/sqleton v0.2.4/go.mod h1:GAGCz4/wsFwzN5mUA3ARmJfqanYu1k5yP4rCUiTeWgs=
 github.com/go-openapi/errors v0.22.0 h1:c4xY/OLxUBSTiepAg3j/MHuAv5mJhnf53LLMWFB+u/w=

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -87,6 +87,7 @@ func NewGeppettoCommand(
 // - WithStepSettings
 // - WithParsedLayers
 // - WithPrinter / Handlers
+// - WithEngine / Temperature / a whole set of LLM specific parameters
 // - potentially others
 //   - WithMessages
 //   - WithPrompt

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -83,6 +83,21 @@ func NewGeppettoCommand(
 	return ret, nil
 }
 
+// XXX this is a mess with all its run methods and all, it would be good to have a RunOption pattern here:
+// - WithStepSettings
+// - WithParsedLayers
+// - WithPrinter / Handlers
+// - potentially others
+//   - WithMessages
+//   - WithPrompt
+//   - WithSystemPrompt
+//   - WithImages
+//   - WithAutosaveSettings
+//   - WithVariables
+//   - WithRouter
+//   - WithStepFactory
+//   - WithSettings
+
 // CreateCommandContextFromParsedLayers creates a new command context from the parsed layers
 func (g *GeppettoCommand) CreateCommandContextFromParsedLayers(
 	parsedLayers *layers.ParsedLayers,

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -111,6 +111,7 @@ func (g *GeppettoCommand) CreateCommandContextFromParsedLayers(
 
 	return g.CreateCommandContextFromSettings(
 		helpersSettings,
+		stepSettings,
 		val.Parameters.ToMap(),
 	)
 }
@@ -118,6 +119,7 @@ func (g *GeppettoCommand) CreateCommandContextFromParsedLayers(
 // CreateCommandContextFromSettings creates a new command context directly from settings
 func (g *GeppettoCommand) CreateCommandContextFromSettings(
 	helpersSettings *cmdlayers.HelpersSettings,
+	stepSettings *settings.StepSettings,
 	variables map[string]interface{},
 ) (*cmdcontext.CommandContext, *cmdcontext.ConversationContext, error) {
 	if g.Prompt != "" && len(g.Messages) != 0 {
@@ -146,7 +148,7 @@ func (g *GeppettoCommand) CreateCommandContextFromSettings(
 	}
 
 	cmdCtx, err := cmdcontext.NewCommandContextFromSettings(
-		g.StepSettings,
+		stepSettings,
 		conversationContext.GetManager(),
 		helpersSettings,
 	)
@@ -164,7 +166,7 @@ func (g *GeppettoCommand) RunWithSettings(
 	variables map[string]interface{},
 	w io.Writer,
 ) error {
-	cmdCtx, _, err := g.CreateCommandContextFromSettings(helpersSettings, variables)
+	cmdCtx, _, err := g.CreateCommandContextFromSettings(helpersSettings, g.StepSettings, variables)
 	if err != nil {
 		return err
 	}
@@ -179,7 +181,7 @@ func (g *GeppettoCommand) RunStepBlockingWithSettings(
 	helpersSettings *cmdlayers.HelpersSettings,
 	variables map[string]interface{},
 ) ([]*conversation.Message, error) {
-	cmdCtx, _, err := g.CreateCommandContextFromSettings(helpersSettings, variables)
+	cmdCtx, _, err := g.CreateCommandContextFromSettings(helpersSettings, g.StepSettings, variables)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmds/cmdcontext/command-context.go
+++ b/pkg/cmds/cmdcontext/command-context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	tea "github.com/charmbracelet/bubbletea"
@@ -106,8 +107,7 @@ func (c *CommandContext) StartInitialStep(
 
 	conversation_ := c.ConversationManager.GetConversation()
 	if c.Settings.PrintPrompt {
-		fmt.Println(conversation_.GetSinglePrompt())
-		return nil, nil
+		return nil, errors.New("Can't run a step with --print-prompt")
 	}
 
 	messagesM := steps.Resolve(conversation_)
@@ -273,6 +273,12 @@ func (c *CommandContext) handleNonChatMode(
 	err := c.Router.RunHandlers(ctx)
 	if err != nil {
 		return err
+	}
+
+	conversation_ := c.ConversationManager.GetConversation()
+	if c.Settings.PrintPrompt {
+		fmt.Printf("%s\n", strings.TrimSpace(conversation_.GetSinglePrompt()))
+		return nil
 	}
 
 	m, err := c.StartInitialStep(ctx)

--- a/pkg/cmds/helpers/parse-helpers.go
+++ b/pkg/cmds/helpers/parse-helpers.go
@@ -1,0 +1,96 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/claude"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/middlewares"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/pinocchio/pkg/cmds"
+	"github.com/go-go-golems/pinocchio/pkg/cmds/cmdlayers"
+)
+
+type GeppettoLayersHelper struct {
+	ProfileFile string
+	Profile     string
+	UseViper    bool
+}
+
+type GeppettoLayersHelperOption func(*GeppettoLayersHelper)
+
+func WithProfileFile(profileFile string) GeppettoLayersHelperOption {
+	return func(h *GeppettoLayersHelper) {
+		h.ProfileFile = profileFile
+	}
+}
+
+func WithProfile(profile string) GeppettoLayersHelperOption {
+	return func(h *GeppettoLayersHelper) {
+		h.Profile = profile
+	}
+}
+
+func WithUseViper(useViper bool) GeppettoLayersHelperOption {
+	return func(h *GeppettoLayersHelper) {
+		h.UseViper = useViper
+	}
+}
+
+func ParseGeppettoLayersFromProfiles(c *cmds.GeppettoCommand, options ...GeppettoLayersHelperOption) (*layers.ParsedLayers, error) {
+	xdgConfigPath, err := os.UserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	defaultProfileFile := fmt.Sprintf("%s/pinocchio/profiles.yaml", xdgConfigPath)
+	helper := &GeppettoLayersHelper{
+		ProfileFile: defaultProfileFile,
+		Profile:     "",
+		UseViper:    true,
+	}
+	for _, option := range options {
+		option(helper)
+	}
+	middlewares_ := []middlewares.Middleware{}
+	if helper.Profile != "" {
+		middlewares_ = append(middlewares_,
+			middlewares.GatherFlagsFromProfiles(
+				helper.ProfileFile,
+				helper.ProfileFile,
+				helper.Profile,
+				parameters.WithParseStepSource("profiles"),
+				parameters.WithParseStepMetadata(map[string]interface{}{
+					"profileFile": helper.ProfileFile,
+					"profile":     helper.Profile,
+				}),
+			),
+		)
+	}
+
+	if helper.UseViper {
+		middlewares_ = append(middlewares_,
+			middlewares.WrapWithWhitelistedLayers(
+				[]string{
+					settings.AiChatSlug,
+					settings.AiClientSlug,
+					openai.OpenAiChatSlug,
+					claude.ClaudeChatSlug,
+					cmdlayers.GeppettoHelpersSlug,
+				},
+				middlewares.GatherFlagsFromViper(parameters.WithParseStepSource("viper")),
+			),
+			middlewares.SetFromDefaults(parameters.WithParseStepSource("defaults")),
+		)
+	}
+
+	geppettoParsedLayers := layers.NewParsedLayers()
+	err = middlewares.ExecuteMiddlewares(c.Description().Layers, geppettoParsedLayers, middlewares_...)
+	if err != nil {
+		return nil, err
+	}
+
+	return geppettoParsedLayers, nil
+}

--- a/pkg/cmds/helpers/parse-helpers.go
+++ b/pkg/cmds/helpers/parse-helpers.go
@@ -40,7 +40,7 @@ func WithUseViper(useViper bool) GeppettoLayersHelperOption {
 	}
 }
 
-func ParseGeppettoLayersFromProfiles(c *cmds.GeppettoCommand, options ...GeppettoLayersHelperOption) (*layers.ParsedLayers, error) {
+func ParseGeppettoLayers(c *cmds.GeppettoCommand, options ...GeppettoLayersHelperOption) (*layers.ParsedLayers, error) {
 	xdgConfigPath, err := os.UserConfigDir()
 	if err != nil {
 		return nil, err

--- a/pkg/cmds/loader.go
+++ b/pkg/cmds/loader.go
@@ -28,6 +28,12 @@ func (g *GeppettoCommandLoader) IsFileSupported(f fs.FS, fileName string) bool {
 
 var _ loaders.CommandLoader = (*GeppettoCommandLoader)(nil)
 
+func LoadFromYAML(b []byte) ([]cmds.Command, error) {
+	loader := &GeppettoCommandLoader{}
+	buf := strings.NewReader(string(b))
+	return loader.loadGeppettoCommandFromReader(buf, nil, nil)
+}
+
 func (g *GeppettoCommandLoader) loadGeppettoCommandFromReader(
 	s io.Reader,
 	options []cmds.CommandDescriptionOption,


### PR DESCRIPTION
- Fix segfault when using --print-prompt flag by properly handling prompt-only mode
- Add new RunStepBlocking method for synchronous execution
- Refactor command context creation into separate methods for better reusability
- Add helper functions for parsing Geppetto layers with profiles

New example:
- Add simple-chat-step example demonstrating basic chat functionality
- Example includes custom flags and templated prompts
- Shows how to properly handle chat messages and print responses