### PR TITLE
Fix chat output handling for text format with caching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,7 +92,19 @@
             }
         },
         {
-            "name": "Pinocchio Test output yaml",
+            "name": "Pinocchio Test output normal (cached)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/pinocchio",
+            "args": ["examples", "test", "--non-interactive", "--with-metadata", "--ai-cache-type", "disk"],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PINOCCHIO_PROFILE": "haiku"
+            }
+        },
+        {
+            "name": "Pinocchio Test output yaml (cached)",
             "type": "go",
             "request": "launch",
             "mode": "auto",

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
 	github.com/go-go-golems/bobatea v0.0.13
 	github.com/go-go-golems/clay v0.1.20
-	github.com/go-go-golems/geppetto v0.4.32
+	github.com/go-go-golems/geppetto v0.4.33
 	github.com/go-go-golems/glazed v0.5.26
 	github.com/go-go-golems/prompto v0.1.8
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/go-go-golems/bobatea v0.0.13 h1:eJBEVML2pSsHVtiqdJpTRvMnDhtI6Kp7gLiBd
 github.com/go-go-golems/bobatea v0.0.13/go.mod h1:+mgkJU0P1rYRq6SwKkFD6FhGAVc+QIDCR/VMKOsU4fI=
 github.com/go-go-golems/clay v0.1.20 h1:KUTbDBA/Q7vgG22B9uBnwDpacwG2+bMavQS8SDwolks=
 github.com/go-go-golems/clay v0.1.20/go.mod h1:hyQirWoEICmaSTcAiPRy7If1n5JEncPi4WVM6tivjoY=
-github.com/go-go-golems/geppetto v0.4.32 h1:XrfW77H0+Iy4qW9XLpifJZnaLrMUd4ku9xEgDyRy5nc=
-github.com/go-go-golems/geppetto v0.4.32/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
+github.com/go-go-golems/geppetto v0.4.33 h1:T+xl2JEn+P0s2/kFQTxtDdQiW1b4hFukL80AGuwCQxM=
+github.com/go-go-golems/geppetto v0.4.33/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
 github.com/go-go-golems/glazed v0.5.26 h1:/Y+Sq6An0IyRVRG1shjV+FZmcOplJ6NvzbQ1edYw3QU=
 github.com/go-go-golems/glazed v0.5.26/go.mod h1:/ZgeDXELDOcAkD505fijARmbF6x5Ev7oewNV4V6Andk=
 github.com/go-go-golems/go-emrichen v0.0.4 h1:U8AKGaxBDjMghiZZe/7sRYiw3UPqRkkbAAc/d2Q9rK4=

--- a/pkg/cmds/cmd.go
+++ b/pkg/cmds/cmd.go
@@ -398,7 +398,7 @@ func (g *PinocchioCommand) runChat(ctx context.Context, rc *run.RunContext) ([]*
 			}
 
 			// Add default printer for initial step
-			if rc.UISettings == nil || rc.UISettings.Output == "" {
+			if rc.UISettings == nil || rc.UISettings.Output == "" || rc.UISettings.Output == "text" {
 				rc.Router.AddHandler("chat", "chat", chat.StepPrinterFunc("", rc.Writer))
 			} else {
 				printer := chat.NewStructuredPrinter(rc.Writer, chat.PrinterOptions{


### PR DESCRIPTION
* Fix chat output printer selection when using text format with caching enabled
* Add explicit handling of "text" output format
* Bump geppetto dependency to v0.4.33