### PR TITLE
Add profiles and config management commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,23 @@ Added a new `profiles` command group to manage pinocchio profiles:
 The profiles command allows managing the profiles.yaml configuration file which contains layer-specific settings for different profiles.
 The init command creates a new profiles file with helpful documentation and examples of the file format.
 
+# Enhanced Profiles List Command
+
+Enhanced the profiles list command to show full profile contents by default, with a new --concise flag to only show profile names.
+
+- Added full profile content display in profiles list command
+- Added --concise/-c flag to show only profile names
+- Updated ListProfiles method to return both names and full content
+
+# Improved Profiles Editor with Ordered Maps
+
+Enhanced the profiles editor to use ordered maps and type aliases for better clarity and consistency:
+
+- Added type aliases for profile, layer, and setting names/values
+- Used ordered maps to preserve the order of layers and settings
+- Updated profiles commands to handle ordered maps
+- Improved code readability with semantic type names
+
 # Previous Changes
 
 // ... existing code ... 

--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,45 @@ Enhanced the profiles editor to use ordered maps and type aliases for better cla
 - Updated profiles commands to handle ordered maps
 - Improved code readability with semantic type names
 
+# Improved Profiles Editor Loading
+
+Modified the profiles editor to load at runtime instead of construction time:
+
+- Profiles editor now loads when commands are executed
+- Improved error handling and logging
+- Fixed directory creation in edit command
+- Consistent with config editor loading behavior
+
+# Added Config Editing Commands
+
+Added a new set of commands for managing the Viper configuration file:
+
+- `config list`: List all configuration keys and values (with --concise flag)
+- `config get`: Get a specific configuration value
+- `config set`: Set a configuration value
+- `config delete`: Delete a configuration value
+- `config edit`: Edit the configuration file in your default editor
+
+The config editor uses Viper to manage the configuration file and provides a simple interface for viewing and modifying settings.
+
+# Improved Config Editor Loading
+
+Modified the config editor to load at runtime instead of construction time:
+
+- Config editor now loads when commands are executed
+- Always uses the current config file from Viper
+- Improved handling of default config path
+- Fixed directory creation in edit command
+
+# Added Profile Duplication Command
+
+Added a new command to duplicate existing profiles:
+
+- Added `profiles duplicate` command to copy profiles
+- Implemented deep copying of YAML nodes to preserve structure
+- Maintains all settings, layers, and comments from source profile
+- Added validation to prevent overwriting existing profiles
+
 # Previous Changes
 
 // ... existing code ... 

--- a/changelog.md
+++ b/changelog.md
@@ -32,3 +32,20 @@ Fixed script handling in web view template:
 - Fixed hx-target attribute to use proper Go string concatenation
 - Added proper templ script handling for onclick events
 - Improved type safety in JavaScript event handling 
+
+# Profile Management Commands
+
+Added a new `profiles` command group to manage pinocchio profiles:
+- `list`: List all available profiles
+- `get`: Get profile settings (entire profile, layer, or specific key)
+- `set`: Set a profile setting
+- `delete`: Delete a profile or specific setting
+- `edit`: Edit the profiles file in your default editor
+- `init`: Initialize a new profiles file with documentation and examples
+
+The profiles command allows managing the profiles.yaml configuration file which contains layer-specific settings for different profiles.
+The init command creates a new profiles file with helpful documentation and examples of the file format.
+
+# Previous Changes
+
+// ... existing code ... 

--- a/cmd/pinocchio/cmds/config.go
+++ b/cmd/pinocchio/cmds/config.go
@@ -96,7 +96,7 @@ func (c *ConfigCommand) newListCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&concise, "concise", "c", false, "Only show keys")
+	cmd.Flags().BoolVarP(&concise, "concise", "c", true, "Only show keys")
 	return cmd
 }
 

--- a/cmd/pinocchio/cmds/config.go
+++ b/cmd/pinocchio/cmds/config.go
@@ -1,9 +1,18 @@
 package cmds
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
 	"github.com/go-go-golems/clay/pkg/cmds/repositories"
 	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/pinocchio/pkg/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rs/zerolog/log"
 )
 
 // commands for manipulating the config
@@ -19,17 +28,176 @@ import (
 // - openai-chat
 // - claude-chat
 
+type ConfigCommand struct {
+	*cobra.Command
+}
+
 func NewConfigGroupCommand(helpSystem *help.HelpSystem) (*cobra.Command, error) {
-	cmd := &cobra.Command{
+	cmd := &ConfigCommand{}
+
+	cobraCmd := &cobra.Command{
 		Use:   "config",
 		Short: "Commands for manipulating configuration and profiles",
 	}
 
-	cmd.AddCommand(repositories.NewRepositoriesGroupCommand())
+	cobraCmd.AddCommand(repositories.NewRepositoriesGroupCommand())
 	err := repositories.AddDocToHelpSystem(helpSystem)
 	if err != nil {
 		return nil, err
 	}
 
-	return cmd, nil
+	cobraCmd.AddCommand(cmd.newListCommand())
+	cobraCmd.AddCommand(cmd.newGetCommand())
+	cobraCmd.AddCommand(cmd.newSetCommand())
+	cobraCmd.AddCommand(cmd.newDeleteCommand())
+	cobraCmd.AddCommand(cmd.newEditCommand())
+
+	cmd.Command = cobraCmd
+	return cobraCmd, nil
+}
+
+// getEditor returns a new ConfigEditor instance for the current config file
+func (c *ConfigCommand) getEditor() (*config.ConfigEditor, error) {
+	configPath := viper.ConfigFileUsed()
+	log.Debug().Str("config_path", configPath).Msg("using config file")
+
+	editor, err := config.NewConfigEditor(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not create config editor: %w", err)
+	}
+
+	return editor, nil
+}
+
+func (c *ConfigCommand) newListCommand() *cobra.Command {
+	var concise bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all configuration keys and values",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor, err := c.getEditor()
+			if err != nil {
+				return err
+			}
+
+			if concise {
+				keys := editor.ListKeys()
+				for _, key := range keys {
+					fmt.Println(key)
+				}
+				return nil
+			}
+
+			settings := editor.GetAll()
+			for key, value := range settings {
+				fmt.Printf("%s: %s\n", key, config.FormatValue(value))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&concise, "concise", "c", false, "Only show keys")
+	return cmd
+}
+
+func (c *ConfigCommand) newGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get a configuration value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor, err := c.getEditor()
+			if err != nil {
+				return err
+			}
+
+			key := args[0]
+			value, err := editor.Get(key)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s\n", config.FormatValue(value))
+			return nil
+		},
+	}
+}
+
+func (c *ConfigCommand) newSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a configuration value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor, err := c.getEditor()
+			if err != nil {
+				return err
+			}
+
+			key := args[0]
+			value := args[1]
+
+			if err := editor.Set(key, value); err != nil {
+				return err
+			}
+
+			return editor.Save()
+		},
+	}
+}
+
+func (c *ConfigCommand) newDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <key>",
+		Short: "Delete a configuration value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor, err := c.getEditor()
+			if err != nil {
+				return err
+			}
+
+			key := args[0]
+
+			if err := editor.Delete(key); err != nil {
+				return err
+			}
+
+			return editor.Save()
+		},
+	}
+}
+
+func (c *ConfigCommand) newEditCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "edit",
+		Short: "Edit the configuration file in your default editor",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor := os.Getenv("EDITOR")
+			if editor == "" {
+				editor = "vim"
+			}
+
+			configPath := viper.ConfigFileUsed()
+			if configPath == "" {
+				var err error
+				configPath, err = config.GetDefaultConfigPath()
+				if err != nil {
+					return err
+				}
+			}
+
+			// Ensure the directory exists
+			if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+				return fmt.Errorf("could not create config directory: %w", err)
+			}
+
+			editCmd := exec.Command(editor, configPath)
+			editCmd.Stdin = os.Stdin
+			editCmd.Stdout = os.Stdout
+			editCmd.Stderr = os.Stderr
+
+			return editCmd.Run()
+		},
+	}
 }

--- a/cmd/pinocchio/cmds/profiles.go
+++ b/cmd/pinocchio/cmds/profiles.go
@@ -1,0 +1,261 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/go-go-golems/pinocchio/pkg/profiles"
+	"github.com/spf13/cobra"
+)
+
+type ProfilesCommand struct {
+	*cobra.Command
+
+	editor *profiles.ProfilesEditor
+}
+
+func NewProfilesCommand() (*ProfilesCommand, error) {
+	profilesPath, err := profiles.GetDefaultProfilesPath()
+	if err != nil {
+		return nil, err
+	}
+
+	editor, err := profiles.NewProfilesEditor(profilesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := &ProfilesCommand{
+		editor: editor,
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "Manage pinocchio profiles",
+	}
+
+	cobraCmd.AddCommand(cmd.newListCommand())
+	cobraCmd.AddCommand(cmd.newGetCommand())
+	cobraCmd.AddCommand(cmd.newSetCommand())
+	cobraCmd.AddCommand(cmd.newDeleteCommand())
+	cobraCmd.AddCommand(cmd.newEditCommand())
+	cobraCmd.AddCommand(cmd.newInitCommand())
+
+	cmd.Command = cobraCmd
+	return cmd, nil
+}
+
+func (c *ProfilesCommand) newListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profiles, err := c.editor.ListProfiles()
+			if err != nil {
+				return err
+			}
+
+			for _, profile := range profiles {
+				fmt.Println(profile)
+			}
+			return nil
+		},
+	}
+}
+
+func (c *ProfilesCommand) newGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <profile> [layer] [key]",
+		Short: "Get profile settings",
+		Args:  cobra.RangeArgs(1, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := args[0]
+
+			if len(args) == 1 {
+				// Show all layers
+				layers, err := c.editor.GetProfileLayers(profile)
+				if err != nil {
+					return err
+				}
+
+				for layer, settings := range layers {
+					fmt.Printf("%s:\n", layer)
+					for key, value := range settings {
+						fmt.Printf("  %s: %s\n", key, value)
+					}
+				}
+				return nil
+			}
+
+			layer := args[1]
+			if len(args) == 2 {
+				// Show all settings for layer
+				layers, err := c.editor.GetProfileLayers(profile)
+				if err != nil {
+					return err
+				}
+
+				settings, ok := layers[layer]
+				if !ok {
+					return fmt.Errorf("layer %s not found in profile %s", layer, profile)
+				}
+
+				for key, value := range settings {
+					fmt.Printf("%s: %s\n", key, value)
+				}
+				return nil
+			}
+
+			// Get specific value
+			key := args[2]
+			value, err := c.editor.GetLayerValue(profile, layer, key)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(value)
+			return nil
+		},
+	}
+}
+
+func (c *ProfilesCommand) newSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <profile> <layer> <key> <value>",
+		Short: "Set a profile setting",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := args[0]
+			layer := args[1]
+			key := args[2]
+			value := args[3]
+
+			if err := c.editor.SetLayerValue(profile, layer, key, value); err != nil {
+				return err
+			}
+
+			return c.editor.Save()
+		},
+	}
+}
+
+func (c *ProfilesCommand) newDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <profile> [layer] [key]",
+		Short: "Delete a profile, layer, or setting",
+		Args:  cobra.RangeArgs(1, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := args[0]
+
+			if len(args) == 1 {
+				// Delete entire profile
+				if err := c.editor.DeleteProfile(profile); err != nil {
+					return err
+				}
+			} else if len(args) == 3 {
+				// Delete specific setting
+				layer := args[1]
+				key := args[2]
+				if err := c.editor.DeleteLayerValue(profile, layer, key); err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("must specify either profile or profile, layer, and key")
+			}
+
+			return c.editor.Save()
+		},
+	}
+}
+
+func (c *ProfilesCommand) newEditCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "edit",
+		Short: "Edit the profiles file in your default editor",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editor := os.Getenv("EDITOR")
+			if editor == "" {
+				editor = "vim"
+			}
+
+			profilesPath, err := profiles.GetDefaultProfilesPath()
+			if err != nil {
+				return err
+			}
+
+			// Ensure the directory exists
+			if err := os.MkdirAll(profilesPath[:len(profilesPath)-len("/profiles.yaml")], 0755); err != nil {
+				return fmt.Errorf("could not create profiles directory: %w", err)
+			}
+
+			editCmd := exec.Command(editor, profilesPath)
+			editCmd.Stdin = os.Stdin
+			editCmd.Stdout = os.Stdout
+			editCmd.Stderr = os.Stderr
+
+			return editCmd.Run()
+		},
+	}
+}
+
+func (c *ProfilesCommand) newInitCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a new profiles file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profilesPath, err := profiles.GetDefaultProfilesPath()
+			if err != nil {
+				return err
+			}
+
+			// Check if file already exists
+			if _, err := os.Stat(profilesPath); err == nil {
+				return fmt.Errorf("profiles file already exists at %s", profilesPath)
+			}
+
+			// Ensure the directory exists
+			if err := os.MkdirAll(profilesPath[:len(profilesPath)-len("/profiles.yaml")], 0755); err != nil {
+				return fmt.Errorf("could not create profiles directory: %w", err)
+			}
+
+			// Create initial profiles file with documentation
+			initialContent := `# Pinocchio Profiles Configuration
+#
+# This file contains profile configurations for Pinocchio.
+# Each profile can override layer parameters for different components.
+#
+# Example:
+#
+# mixtral:
+#   openai-chat:
+#     openai-base-url: https://api.endpoints.anyscale.com/v1
+#     openai-api-key: XXX
+#   ai-chat:
+#     ai-engine: mistralai/Mixtral-8x7B-Instruct-v0.1
+#     ai-api-type: openai
+#
+# mistral:
+#   openai-chat:
+#     openai-base-url: https://api.endpoints.anyscale.com/v1
+#     openai-api-key: XXX
+#   ai-chat:
+#     ai-engine: mistralai/Mistral-7B-Instruct-v0.1
+#     ai-api-type: openai
+#
+# You can manage this file using the 'pinocchio profiles' commands:
+# - list: List all profiles
+# - get: Get profile settings
+# - set: Set a profile setting
+# - delete: Delete a profile or setting
+# - edit: Open this file in your editor
+`
+			if err := os.WriteFile(profilesPath, []byte(initialContent), 0644); err != nil {
+				return fmt.Errorf("could not write profiles file: %w", err)
+			}
+
+			fmt.Printf("Created new profiles file at %s\n", profilesPath)
+			return nil
+		},
+	}
+}

--- a/cmd/pinocchio/cmds/profiles.go
+++ b/cmd/pinocchio/cmds/profiles.go
@@ -82,7 +82,7 @@ func (c *ProfilesCommand) newListCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&concise, "concise", "c", false, "Only show profile names")
+	cmd.Flags().BoolVarP(&concise, "concise", "c", true, "Only show profile names")
 	return cmd
 }
 

--- a/cmd/pinocchio/cmds/profiles.go
+++ b/cmd/pinocchio/cmds/profiles.go
@@ -91,7 +91,7 @@ func (c *ProfilesCommand) newListCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&concise, "concise", "c", false, "Only show profile names")
+	cmd.Flags().BoolVarP(&concise, "concise", "c", true, "Only show profile names")
 	return cmd
 }
 

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -248,3 +248,13 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 
 	return nil
 }
+
+func init() {
+	// Add profiles command
+	profilesCmd, err := pinocchio_cmds.NewProfilesCommand()
+	if err != nil {
+		fmt.Printf("Error initializing profiles command: %v\n", err)
+		os.Exit(1)
+	}
+	rootCmd.AddCommand(profilesCmd.Command)
+}

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -216,6 +216,14 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 	}
 	rootCmd.AddCommand(command)
 
+	// Add profiles command
+	profilesCmd, err := pinocchio_cmds.NewProfilesCommand()
+	if err != nil {
+		fmt.Printf("Error initializing profiles command: %v\n", err)
+		os.Exit(1)
+	}
+	rootCmd.AddCommand(profilesCmd)
+
 	catter.AddToRootCommand(rootCmd)
 
 	promptoCommand, err := prompto.InitPromptoCmd(helpSystem)
@@ -250,11 +258,4 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 }
 
 func init() {
-	// Add profiles command
-	profilesCmd, err := pinocchio_cmds.NewProfilesCommand()
-	if err != nil {
-		fmt.Printf("Error initializing profiles command: %v\n", err)
-		os.Exit(1)
-	}
-	rootCmd.AddCommand(profilesCmd.Command)
 }

--- a/cmd/pinocchio/prompts/create-command.yaml
+++ b/cmd/pinocchio/prompts/create-command.yaml
@@ -216,4 +216,5 @@ prompt: |
     {{ "{{" }} end }}
   ```
 
-  Ensure that your final YAML template is properly formatted, indented, and addresses all sections according to the instructions above. Present your final YAML template enclosed in <yaml_template> tags.
+  Ensure that your final YAML template is properly formatted, indented, and addresses all sections according to the instructions above.
+   Present your final YAML template enclosed in <yaml_template> tags.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
 	github.com/go-go-golems/bobatea v0.0.13
-	github.com/go-go-golems/clay v0.1.22
+	github.com/go-go-golems/clay v0.1.23
 	github.com/go-go-golems/geppetto v0.4.34
 	github.com/go-go-golems/glazed v0.5.27
 	github.com/go-go-golems/prompto v0.1.8
@@ -33,6 +33,7 @@ require (
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	github.com/tiktoken-go/tokenizer v0.2.0
 	github.com/weaviate/tiktoken-go v0.0.2
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/sync v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -114,7 +115,6 @@ require (
 	github.com/tj/go-naturaldate v1.3.0 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/weaviate/weaviate-go-client/v4 v4.14.0 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 // indirect
 	github.com/xuri/excelize/v2 v2.7.1 // indirect
 	github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
 	github.com/go-go-golems/bobatea v0.0.13
-	github.com/go-go-golems/clay v0.1.20
+	github.com/go-go-golems/clay v0.1.22
 	github.com/go-go-golems/geppetto v0.4.34
-	github.com/go-go-golems/glazed v0.5.26
+	github.com/go-go-golems/glazed v0.5.27
 	github.com/go-go-golems/prompto v0.1.8
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-go-golems/bobatea v0.0.13 h1:eJBEVML2pSsHVtiqdJpTRvMnDhtI6Kp7gLiBd+LM3pI=
 github.com/go-go-golems/bobatea v0.0.13/go.mod h1:+mgkJU0P1rYRq6SwKkFD6FhGAVc+QIDCR/VMKOsU4fI=
-github.com/go-go-golems/clay v0.1.22 h1:07+W31MjaGMxd296bgNCaNeFasCHhiVLiMPqT/VhPVA=
-github.com/go-go-golems/clay v0.1.22/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
+github.com/go-go-golems/clay v0.1.23 h1:IPzxS1mTcU1GWjkjON5ed+mpjqhGVvXmn6M6cplpJr4=
+github.com/go-go-golems/clay v0.1.23/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
 github.com/go-go-golems/geppetto v0.4.34 h1:kVQqVqrXPPa+4tRPqAxTbvOAomM9XKd255nuUdBFCfE=
 github.com/go-go-golems/geppetto v0.4.34/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
 github.com/go-go-golems/glazed v0.5.27 h1:rTzxL0vp/uBxVvZqJsyIxIFZ1zN/CSJ5qOtc8j87gBs=

--- a/go.sum
+++ b/go.sum
@@ -91,12 +91,12 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-go-golems/bobatea v0.0.13 h1:eJBEVML2pSsHVtiqdJpTRvMnDhtI6Kp7gLiBd+LM3pI=
 github.com/go-go-golems/bobatea v0.0.13/go.mod h1:+mgkJU0P1rYRq6SwKkFD6FhGAVc+QIDCR/VMKOsU4fI=
-github.com/go-go-golems/clay v0.1.20 h1:KUTbDBA/Q7vgG22B9uBnwDpacwG2+bMavQS8SDwolks=
-github.com/go-go-golems/clay v0.1.20/go.mod h1:hyQirWoEICmaSTcAiPRy7If1n5JEncPi4WVM6tivjoY=
+github.com/go-go-golems/clay v0.1.22 h1:07+W31MjaGMxd296bgNCaNeFasCHhiVLiMPqT/VhPVA=
+github.com/go-go-golems/clay v0.1.22/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
 github.com/go-go-golems/geppetto v0.4.34 h1:kVQqVqrXPPa+4tRPqAxTbvOAomM9XKd255nuUdBFCfE=
 github.com/go-go-golems/geppetto v0.4.34/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
-github.com/go-go-golems/glazed v0.5.26 h1:/Y+Sq6An0IyRVRG1shjV+FZmcOplJ6NvzbQ1edYw3QU=
-github.com/go-go-golems/glazed v0.5.26/go.mod h1:/ZgeDXELDOcAkD505fijARmbF6x5Ev7oewNV4V6Andk=
+github.com/go-go-golems/glazed v0.5.27 h1:rTzxL0vp/uBxVvZqJsyIxIFZ1zN/CSJ5qOtc8j87gBs=
+github.com/go-go-golems/glazed v0.5.27/go.mod h1:/ZgeDXELDOcAkD505fijARmbF6x5Ev7oewNV4V6Andk=
 github.com/go-go-golems/go-emrichen v0.0.4 h1:U8AKGaxBDjMghiZZe/7sRYiw3UPqRkkbAAc/d2Q9rK4=
 github.com/go-go-golems/go-emrichen v0.0.4/go.mod h1:yYf0DLUYLLZdvCODdpIBYUxgNz0ZomJFlGhhzlg+fs0=
 github.com/go-go-golems/prompto v0.1.8 h1:SX2gYo2m3RDvx10/S9j5FVpHCAorOmd6DVG8+XuBiN0=

--- a/pkg/config/editor.go
+++ b/pkg/config/editor.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+)
+
+type ConfigEditor struct {
+	viper *viper.Viper
+	path  string
+}
+
+func NewConfigEditor(path string) (*ConfigEditor, error) {
+	log.Debug().Msgf("Creating config editor for path: %s", path)
+	v := viper.New()
+	v.SetConfigFile(path)
+
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("could not create config directory: %w", err)
+	}
+
+	// Try to read config, but don't fail if it doesn't exist
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, fmt.Errorf("could not read config: %w", err)
+		}
+	}
+
+	return &ConfigEditor{
+		viper: v,
+		path:  path,
+	}, nil
+}
+
+func (c *ConfigEditor) Save() error {
+	return c.viper.WriteConfig()
+}
+
+func (c *ConfigEditor) Set(key string, value interface{}) error {
+	c.viper.Set(key, value)
+	return nil
+}
+
+func (c *ConfigEditor) Get(key string) (interface{}, error) {
+	if !c.viper.IsSet(key) {
+		return nil, fmt.Errorf("key not found: %s", key)
+	}
+	return c.viper.Get(key), nil
+}
+
+func (c *ConfigEditor) Delete(key string) error {
+	if !c.viper.IsSet(key) {
+		return fmt.Errorf("key not found: %s", key)
+	}
+	c.viper.Set(key, nil)
+	return nil
+}
+
+func (c *ConfigEditor) ListKeys() []string {
+	var allKeys []string
+	allKeys = append(allKeys, c.viper.AllKeys()...)
+	return allKeys
+}
+
+func (c *ConfigEditor) GetAll() map[string]interface{} {
+	return c.viper.AllSettings()
+}
+
+func GetDefaultConfigPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("could not get config dir: %w", err)
+	}
+
+	return filepath.Join(configDir, "pinocchio", "config.yaml"), nil
+}
+
+// Helper function to format config values for display
+func FormatValue(value interface{}) string {
+	switch v := value.(type) {
+	case []interface{}:
+		var items []string
+		for _, item := range v {
+			items = append(items, fmt.Sprintf("%v", item))
+		}
+		return fmt.Sprintf("[%s]", strings.Join(items, ", "))
+	case map[string]interface{}:
+		var items []string
+		for k, val := range v {
+			items = append(items, fmt.Sprintf("%s: %v", k, val))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(items, ", "))
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}

--- a/pkg/profiles/editor.go
+++ b/pkg/profiles/editor.go
@@ -1,0 +1,114 @@
+package profiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	yaml_editor "github.com/go-go-golems/clay/pkg/yaml-editor"
+	"gopkg.in/yaml.v3"
+)
+
+type ProfilesEditor struct {
+	editor *yaml_editor.YAMLEditor
+	path   string
+}
+
+func NewProfilesEditor(path string) (*ProfilesEditor, error) {
+	editor, err := yaml_editor.NewYAMLEditorFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not create editor: %w", err)
+	}
+
+	return &ProfilesEditor{
+		editor: editor,
+		path:   path,
+	}, nil
+}
+
+func (p *ProfilesEditor) Save() error {
+	return p.editor.Save(p.path)
+}
+
+func (p *ProfilesEditor) SetLayerValue(profile, layer, key, value string) error {
+	valueNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: value,
+	}
+	return p.editor.SetNode(valueNode, profile, layer, key)
+}
+
+func (p *ProfilesEditor) GetLayerValue(profile, layer, key string) (string, error) {
+	node, err := p.editor.GetNode(profile, layer, key)
+	if err != nil {
+		return "", fmt.Errorf("could not get value: %w", err)
+	}
+	return node.Value, nil
+}
+
+func (p *ProfilesEditor) DeleteProfile(profile string) error {
+	return p.editor.SetNode(nil, profile)
+}
+
+func (p *ProfilesEditor) DeleteLayerValue(profile, layer, key string) error {
+	return p.editor.SetNode(nil, profile, layer, key)
+}
+
+func (p *ProfilesEditor) ListProfiles() ([]string, error) {
+	root, err := p.editor.GetNode()
+	if err != nil {
+		return nil, fmt.Errorf("could not get root node: %w", err)
+	}
+
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("root node is not a mapping")
+	}
+
+	profiles := make([]string, 0)
+	for i := 0; i < len(root.Content); i += 2 {
+		profiles = append(profiles, root.Content[i].Value)
+	}
+
+	return profiles, nil
+}
+
+func (p *ProfilesEditor) GetProfileLayers(profile string) (map[string]map[string]string, error) {
+	profileNode, err := p.editor.GetNode(profile)
+	if err != nil {
+		return nil, fmt.Errorf("could not get profile: %w", err)
+	}
+
+	if profileNode.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("profile node is not a mapping")
+	}
+
+	layers := make(map[string]map[string]string)
+	for i := 0; i < len(profileNode.Content); i += 2 {
+		layerName := profileNode.Content[i].Value
+		layerNode := profileNode.Content[i+1]
+
+		if layerNode.Kind != yaml.MappingNode {
+			continue
+		}
+
+		settings := make(map[string]string)
+		for j := 0; j < len(layerNode.Content); j += 2 {
+			key := layerNode.Content[j].Value
+			value := layerNode.Content[j+1].Value
+			settings[key] = value
+		}
+
+		layers[layerName] = settings
+	}
+
+	return layers, nil
+}
+
+func GetDefaultProfilesPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("could not get config dir: %w", err)
+	}
+
+	return filepath.Join(configDir, "pinocchio", "profiles.yaml"), nil
+}


### PR DESCRIPTION
Adds two new command groups for managing configuration:

Profiles Commands:
- `profiles list`: List available profiles (--concise flag for names only)
- `profiles get`: Get profile settings (entire profile/layer/key)
- `profiles set`: Set profile settings
- `profiles delete`: Delete profiles or settings
- `profiles edit`: Edit profiles file directly
- `profiles init`: Create new profiles file with documentation
- `profiles duplicate`: Copy existing profiles

Config Commands:
- `config list`: List config values (--concise flag for keys only) 
- `config get`: Get config value
- `config set`: Set config value
- `config delete`: Delete config value
- `config edit`: Edit config file directly

Key Implementation Details:
- Uses ordered maps to preserve YAML structure
- Runtime loading of config/profiles files
- Deep copy for profile duplication
- Proper directory creation and file handling
- Consistent editor loading behavior

The commands provide a complete interface for managing both profiles.yaml and 
config.yaml files through CLI or direct editing.