### PR TITLE
Add tool name to tool result messages

### DIFF
--- a/cmd/web-chat/web/src/sem/pb/proto/sem/base/tool_pb.ts
+++ b/cmd/web-chat/web/src/sem/pb/proto/sem/base/tool_pb.ts
@@ -11,7 +11,7 @@ import type { JsonObject, Message } from "@bufbuild/protobuf";
  * Describes the file proto/sem/base/tool.proto.
  */
 export const file_proto_sem_base_tool: GenFile = /*@__PURE__*/
-  fileDesc("Chlwcm90by9zZW0vYmFzZS90b29sLnByb3RvEg1zZW0uYmFzZS50b29sIk0KCVRvb2xTdGFydBIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEiYKBWlucHV0GAMgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdCI/CglUb29sRGVsdGESCgoCaWQYASABKAkSJgoFcGF0Y2gYAiABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Ij0KClRvb2xSZXN1bHQSCgoCaWQYASABKAkSDgoGcmVzdWx0GAIgASgJEhMKC2N1c3RvbV9raW5kGAMgASgJIhYKCFRvb2xEb25lEgoKAmlkGAEgASgJQkJaQGdpdGh1Yi5jb20vZ28tZ28tZ29sZW1zL3Bpbm9jY2hpby9wa2cvc2VtL3BiL3Byb3RvL3NlbS9iYXNlO2Jhc2ViBnByb3RvMw", [file_google_protobuf_struct]);
+  fileDesc("Chlwcm90by9zZW0vYmFzZS90b29sLnByb3RvEg1zZW0uYmFzZS50b29sIk0KCVRvb2xTdGFydBIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEiYKBWlucHV0GAMgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdCI/CglUb29sRGVsdGESCgoCaWQYASABKAkSJgoFcGF0Y2gYAiABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0IksKClRvb2xSZXN1bHQSCgoCaWQYASABKAkSDgoGcmVzdWx0GAIgASgJEhMKC2N1c3RvbV9raW5kGAMgASgJEgwKBG5hbWUYBCABKAkiFgoIVG9vbERvbmUSCgoCaWQYASABKAlCQlpAZ2l0aHViLmNvbS9nby1nby1nb2xlbXMvcGlub2NjaGlvL3BrZy9zZW0vcGIvcHJvdG8vc2VtL2Jhc2U7YmFzZWIGcHJvdG8z", [file_google_protobuf_struct]);
 
 /**
  * @generated from message sem.base.tool.ToolStart
@@ -84,6 +84,13 @@ export type ToolResult = Message<"sem.base.tool.ToolResult"> & {
    * @generated from field: string custom_kind = 3;
    */
   customKind: string;
+
+  /**
+   * optional: tool name for cleaner downstream projection/rendering
+   *
+   * @generated from field: string name = 4;
+   */
+  name: string;
 };
 
 /**

--- a/cmd/web-chat/web/src/sem/pb/proto/sem/timeline/tool_pb.ts
+++ b/cmd/web-chat/web/src/sem/pb/proto/sem/timeline/tool_pb.ts
@@ -11,7 +11,7 @@ import type { JsonObject, Message } from "@bufbuild/protobuf";
  * Describes the file proto/sem/timeline/tool.proto.
  */
 export const file_proto_sem_timeline_tool: GenFile = /*@__PURE__*/
-  fileDesc("Ch1wcm90by9zZW0vdGltZWxpbmUvdG9vbC5wcm90bxIMc2VtLnRpbWVsaW5lIpIBChJUb29sQ2FsbFNuYXBzaG90VjESFgoOc2NoZW1hX3ZlcnNpb24YASABKA0SDAoEbmFtZRgCIAEoCRImCgVpbnB1dBgDIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3QSDgoGc3RhdHVzGAQgASgJEhAKCHByb2dyZXNzGAUgASgBEgwKBGRvbmUYBiABKAgipQEKFFRvb2xSZXN1bHRTbmFwc2hvdFYxEhYKDnNjaGVtYV92ZXJzaW9uGAEgASgNEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRInCgZyZXN1bHQYAyABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Eg0KBWVycm9yGAQgASgJEhIKCnJlc3VsdF9yYXcYBSABKAkSEwoLY3VzdG9tX2tpbmQYBiABKAlCSlpIZ2l0aHViLmNvbS9nby1nby1nb2xlbXMvcGlub2NjaGlvL3BrZy9zZW0vcGIvcHJvdG8vc2VtL3RpbWVsaW5lO3RpbWVsaW5lYgZwcm90bzM", [file_google_protobuf_struct]);
+  fileDesc("Ch1wcm90by9zZW0vdGltZWxpbmUvdG9vbC5wcm90bxIMc2VtLnRpbWVsaW5lIpIBChJUb29sQ2FsbFNuYXBzaG90VjESFgoOc2NoZW1hX3ZlcnNpb24YASABKA0SDAoEbmFtZRgCIAEoCRImCgVpbnB1dBgDIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3QSDgoGc3RhdHVzGAQgASgJEhAKCHByb2dyZXNzGAUgASgBEgwKBGRvbmUYBiABKAgiswEKFFRvb2xSZXN1bHRTbmFwc2hvdFYxEhYKDnNjaGVtYV92ZXJzaW9uGAEgASgNEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRInCgZyZXN1bHQYAyABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Eg0KBWVycm9yGAQgASgJEhIKCnJlc3VsdF9yYXcYBSABKAkSEwoLY3VzdG9tX2tpbmQYBiABKAkSDAoEbmFtZRgHIAEoCUJKWkhnaXRodWIuY29tL2dvLWdvLWdvbGVtcy9waW5vY2NoaW8vcGtnL3NlbS9wYi9wcm90by9zZW0vdGltZWxpbmU7dGltZWxpbmViBnByb3RvMw", [file_google_protobuf_struct]);
 
 /**
  * ToolCallSnapshotV1 defines the payload for a 'tool_call' entity.
@@ -112,6 +112,13 @@ export type ToolResultSnapshotV1 = Message<"sem.timeline.ToolResultSnapshotV1"> 
    * @generated from field: string custom_kind = 6;
    */
   customKind: string;
+
+  /**
+   * Optional: tool name for cleaner downstream projection/rendering.
+   *
+   * @generated from field: string name = 7;
+   */
+  name: string;
 };
 
 /**

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/bobatea v0.1.5
 	github.com/go-go-golems/clay v0.4.0
-	github.com/go-go-golems/geppetto v0.11.8
+	github.com/go-go-golems/geppetto v0.11.9
 	github.com/go-go-golems/glazed v1.0.6
 	github.com/go-go-golems/go-go-goja v0.4.6
 	github.com/go-go-golems/uhoh v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/go-go-golems/bobatea v0.1.5 h1:WjY9dxJcTy+iGOoE9ROriSt6+m7j1Fedp2lUGN
 github.com/go-go-golems/bobatea v0.1.5/go.mod h1:FB1zWnEyIUOBDwtTXN7qRSEA8C7lxZ5KbowTUoHaa0g=
 github.com/go-go-golems/clay v0.4.0 h1:8VeR+o3ah9P95TWLFtitSLabF567AzhjjoeYK87vEwM=
 github.com/go-go-golems/clay v0.4.0/go.mod h1:8wx9hz+dUN4jodWN4CzfMqjBfcXyZ4X6DaJfFFAI8eE=
-github.com/go-go-golems/geppetto v0.11.8 h1:ySo6D11nCG/KmMBAL70pSIYZJtv4SOE3RBejHMpOlNM=
-github.com/go-go-golems/geppetto v0.11.8/go.mod h1:/gabONRxhHhFn0XNcGZHgEhLkHKBNTKkKrDsLvEuLQw=
+github.com/go-go-golems/geppetto v0.11.9 h1:NISixpLRq5msRCWcybsxdMyF92BrfDpv1UZNiNQYzY4=
+github.com/go-go-golems/geppetto v0.11.9/go.mod h1:/gabONRxhHhFn0XNcGZHgEhLkHKBNTKkKrDsLvEuLQw=
 github.com/go-go-golems/glazed v1.0.6 h1:TpMrjo73fGYzXmpyce5wKO0AXnYcyuugPVGdbx0LQqM=
 github.com/go-go-golems/glazed v1.0.6/go.mod h1:bZfc0SiVzOAHPOmAkWHLNjckeIK0fOgffjny2ZOUwSQ=
 github.com/go-go-golems/go-go-goja v0.4.6 h1:3qgyjc7RZuMTpDo3C06xDamLMCl0F6hCr6H3fEkjmmI=

--- a/pkg/sem/pb/proto/sem/base/tool.pb.go
+++ b/pkg/sem/pb/proto/sem/base/tool.pb.go
@@ -139,6 +139,7 @@ type ToolResult struct {
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Result        string                 `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`                           // raw string; may contain JSON
 	CustomKind    string                 `protobuf:"bytes,3,opt,name=custom_kind,json=customKind,proto3" json:"custom_kind,omitempty"` // optional: custom renderer hint (e.g. "calc_result")
+	Name          string                 `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`                               // optional: tool name for cleaner downstream projection/rendering
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -190,6 +191,13 @@ func (x *ToolResult) GetResult() string {
 func (x *ToolResult) GetCustomKind() string {
 	if x != nil {
 		return x.CustomKind
+	}
+	return ""
+}
+
+func (x *ToolResult) GetName() string {
+	if x != nil {
+		return x.Name
 	}
 	return ""
 }
@@ -249,13 +257,14 @@ const file_proto_sem_base_tool_proto_rawDesc = "" +
 	"\x05input\x18\x03 \x01(\v2\x17.google.protobuf.StructR\x05input\"J\n" +
 	"\tToolDelta\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12-\n" +
-	"\x05patch\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x05patch\"U\n" +
+	"\x05patch\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x05patch\"i\n" +
 	"\n" +
 	"ToolResult\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06result\x18\x02 \x01(\tR\x06result\x12\x1f\n" +
 	"\vcustom_kind\x18\x03 \x01(\tR\n" +
-	"customKind\"\x1a\n" +
+	"customKind\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\"\x1a\n" +
 	"\bToolDone\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02idBBZ@github.com/go-go-golems/pinocchio/pkg/sem/pb/proto/sem/base;baseb\x06proto3"
 

--- a/pkg/sem/pb/proto/sem/timeline/tool.pb.go
+++ b/pkg/sem/pb/proto/sem/timeline/tool.pb.go
@@ -117,7 +117,9 @@ type ToolResultSnapshotV1 struct {
 	// Optional: raw result text when the tool result is not structured JSON.
 	ResultRaw string `protobuf:"bytes,5,opt,name=result_raw,json=resultRaw,proto3" json:"result_raw,omitempty"`
 	// Optional: renderer hint (e.g. "calc_result") carried through from SEM tool.result.
-	CustomKind    string `protobuf:"bytes,6,opt,name=custom_kind,json=customKind,proto3" json:"custom_kind,omitempty"`
+	CustomKind string `protobuf:"bytes,6,opt,name=custom_kind,json=customKind,proto3" json:"custom_kind,omitempty"`
+	// Optional: tool name for cleaner downstream projection/rendering.
+	Name          string `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -194,6 +196,13 @@ func (x *ToolResultSnapshotV1) GetCustomKind() string {
 	return ""
 }
 
+func (x *ToolResultSnapshotV1) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 var File_proto_sem_timeline_tool_proto protoreflect.FileDescriptor
 
 const file_proto_sem_timeline_tool_proto_rawDesc = "" +
@@ -205,7 +214,7 @@ const file_proto_sem_timeline_tool_proto_rawDesc = "" +
 	"\x05input\x18\x03 \x01(\v2\x17.google.protobuf.StructR\x05input\x12\x16\n" +
 	"\x06status\x18\x04 \x01(\tR\x06status\x12\x1a\n" +
 	"\bprogress\x18\x05 \x01(\x01R\bprogress\x12\x12\n" +
-	"\x04done\x18\x06 \x01(\bR\x04done\"\xe6\x01\n" +
+	"\x04done\x18\x06 \x01(\bR\x04done\"\xfa\x01\n" +
 	"\x14ToolResultSnapshotV1\x12%\n" +
 	"\x0eschema_version\x18\x01 \x01(\rR\rschemaVersion\x12 \n" +
 	"\ftool_call_id\x18\x02 \x01(\tR\n" +
@@ -215,7 +224,8 @@ const file_proto_sem_timeline_tool_proto_rawDesc = "" +
 	"\n" +
 	"result_raw\x18\x05 \x01(\tR\tresultRaw\x12\x1f\n" +
 	"\vcustom_kind\x18\x06 \x01(\tR\n" +
-	"customKindBJZHgithub.com/go-go-golems/pinocchio/pkg/sem/pb/proto/sem/timeline;timelineb\x06proto3"
+	"customKind\x12\x12\n" +
+	"\x04name\x18\a \x01(\tR\x04nameBJZHgithub.com/go-go-golems/pinocchio/pkg/sem/pb/proto/sem/timeline;timelineb\x06proto3"
 
 var (
 	file_proto_sem_timeline_tool_proto_rawDescOnce sync.Once

--- a/pkg/webchat/sem_translator.go
+++ b/pkg/webchat/sem_translator.go
@@ -57,6 +57,14 @@ func protoToRaw(m proto.Message) (json.RawMessage, error) {
 	return json.RawMessage(b), nil
 }
 
+func toolResultRaw(ev events.ToolResult, customKind string, fallbackName string) (json.RawMessage, error) {
+	name := strings.TrimSpace(ev.Name)
+	if name == "" {
+		name = strings.TrimSpace(fallbackName)
+	}
+	return protoToRaw(&sempb.ToolResult{Id: ev.ID, Result: ev.Result, CustomKind: customKind, Name: name})
+}
+
 func mapToStruct(m map[string]any) (*structpb.Struct, error) {
 	if len(m) == 0 {
 		return nil, nil
@@ -443,7 +451,7 @@ func (et *EventTranslator) RegisterDefaultHandlers() {
 		var frames [][]byte
 		if v, ok := et.toolCallCache.Load(ev.ToolResult.ID); ok {
 			if ctc, ok2 := v.(cachedToolCall); ok2 && ctc.Name == "calc" {
-				resultData, err := protoToRaw(&sempb.ToolResult{Id: ev.ToolResult.ID, Result: ev.ToolResult.Result, CustomKind: "calc_result"})
+				resultData, err := toolResultRaw(ev.ToolResult, "calc_result", ctc.Name)
 				if err != nil {
 					return nil, err
 				}
@@ -456,7 +464,13 @@ func (et *EventTranslator) RegisterDefaultHandlers() {
 				return frames, nil
 			}
 		}
-		resultData, err := protoToRaw(&sempb.ToolResult{Id: ev.ToolResult.ID, Result: ev.ToolResult.Result})
+		var fallbackName string
+		if v, ok := et.toolCallCache.Load(ev.ToolResult.ID); ok {
+			if ctc, ok2 := v.(cachedToolCall); ok2 {
+				fallbackName = ctc.Name
+			}
+		}
+		resultData, err := toolResultRaw(ev.ToolResult, "", fallbackName)
 		if err != nil {
 			return nil, err
 		}
@@ -473,7 +487,7 @@ func (et *EventTranslator) RegisterDefaultHandlers() {
 		var frames [][]byte
 		if v, ok := et.toolCallCache.Load(ev.ToolResult.ID); ok {
 			if ctc, ok2 := v.(cachedToolCall); ok2 && ctc.Name == "calc" {
-				resultData, err := protoToRaw(&sempb.ToolResult{Id: ev.ToolResult.ID, Result: ev.ToolResult.Result, CustomKind: "calc_result"})
+				resultData, err := toolResultRaw(ev.ToolResult, "calc_result", ctc.Name)
 				if err != nil {
 					return nil, err
 				}
@@ -486,7 +500,13 @@ func (et *EventTranslator) RegisterDefaultHandlers() {
 				return frames, nil
 			}
 		}
-		resultData, err := protoToRaw(&sempb.ToolResult{Id: ev.ToolResult.ID, Result: ev.ToolResult.Result})
+		var fallbackName string
+		if v, ok := et.toolCallCache.Load(ev.ToolResult.ID); ok {
+			if ctc, ok2 := v.(cachedToolCall); ok2 {
+				fallbackName = ctc.Name
+			}
+		}
+		resultData, err := toolResultRaw(ev.ToolResult, "", fallbackName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webchat/sem_translator_test.go
+++ b/pkg/webchat/sem_translator_test.go
@@ -120,8 +120,28 @@ func TestSemanticEventsFromEvent_CalcToolResultGetsCustomKind(t *testing.T) {
 	require.Equal(t, "tool.result", resEv["type"])
 	resData, ok := resEv["data"].(map[string]any)
 	require.True(t, ok)
+	require.Equal(t, "calc", resData["name"])
 	require.Equal(t, "calc_result", resData["customKind"])
 	require.Equal(t, "tool.done", doneEv["type"])
+}
+
+func TestSemanticEventsFromEvent_ToolResultIncludesName(t *testing.T) {
+	meta := events.EventMetadata{SessionID: "sess-4", InferenceID: "inf-4", TurnID: "turn-4"}
+
+	toolCall := events.ToolCall{ID: "tc-2", Name: "sql_query", Input: `{"sql":"SELECT 1"}`}
+	callFrames := SemanticEventsFromEvent(events.NewToolCallEvent(meta, toolCall))
+	require.Len(t, callFrames, 1)
+	callEv := decodeSemEvent(t, callFrames[0])
+	require.Equal(t, "tool.start", callEv["type"])
+
+	toolResult := events.ToolResult{ID: "tc-2", Name: "sql_query", Result: `{"ok":true}`}
+	resultFrames := SemanticEventsFromEvent(events.NewToolResultEvent(meta, toolResult))
+	require.Len(t, resultFrames, 2)
+	resEv := decodeSemEvent(t, resultFrames[0])
+	require.Equal(t, "tool.result", resEv["type"])
+	resData, ok := resEv["data"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "sql_query", resData["name"])
 }
 
 func TestSemanticEventsFromEvent_ReasoningSummaryMapsToThinkingSummary(t *testing.T) {

--- a/pkg/webchat/timeline_projector.go
+++ b/pkg/webchat/timeline_projector.go
@@ -311,6 +311,7 @@ func (p *TimelineProjector) ApplySemFrame(ctx context.Context, frame []byte) err
 			Result:        resultStruct,
 			ResultRaw:     pb.Result,
 			CustomKind:    pb.CustomKind,
+			Name:          pb.Name,
 		}))
 		return err
 

--- a/proto/sem/base/tool.proto
+++ b/proto/sem/base/tool.proto
@@ -21,9 +21,9 @@ message ToolResult {
   string id = 1;
   string result = 2; // raw string; may contain JSON
   string custom_kind = 3; // optional: custom renderer hint (e.g. "calc_result")
+  string name = 4; // optional: tool name for cleaner downstream projection/rendering
 }
 
 message ToolDone {
   string id = 1;
 }
-

--- a/proto/sem/timeline/tool.proto
+++ b/proto/sem/timeline/tool.proto
@@ -26,4 +26,6 @@ message ToolResultSnapshotV1 {
   string result_raw = 5;
   // Optional: renderer hint (e.g. "calc_result") carried through from SEM tool.result.
   string custom_kind = 6;
+  // Optional: tool name for cleaner downstream projection/rendering.
+  string name = 7;
 }

--- a/web/src/sem/pb/proto/sem/base/tool_pb.ts
+++ b/web/src/sem/pb/proto/sem/base/tool_pb.ts
@@ -11,7 +11,7 @@ import type { JsonObject, Message } from "@bufbuild/protobuf";
  * Describes the file proto/sem/base/tool.proto.
  */
 export const file_proto_sem_base_tool: GenFile = /*@__PURE__*/
-  fileDesc("Chlwcm90by9zZW0vYmFzZS90b29sLnByb3RvEg1zZW0uYmFzZS50b29sIk0KCVRvb2xTdGFydBIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEiYKBWlucHV0GAMgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdCI/CglUb29sRGVsdGESCgoCaWQYASABKAkSJgoFcGF0Y2gYAiABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Ij0KClRvb2xSZXN1bHQSCgoCaWQYASABKAkSDgoGcmVzdWx0GAIgASgJEhMKC2N1c3RvbV9raW5kGAMgASgJIhYKCFRvb2xEb25lEgoKAmlkGAEgASgJQkJaQGdpdGh1Yi5jb20vZ28tZ28tZ29sZW1zL3Bpbm9jY2hpby9wa2cvc2VtL3BiL3Byb3RvL3NlbS9iYXNlO2Jhc2ViBnByb3RvMw", [file_google_protobuf_struct]);
+  fileDesc("Chlwcm90by9zZW0vYmFzZS90b29sLnByb3RvEg1zZW0uYmFzZS50b29sIk0KCVRvb2xTdGFydBIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEiYKBWlucHV0GAMgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdCI/CglUb29sRGVsdGESCgoCaWQYASABKAkSJgoFcGF0Y2gYAiABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0IksKClRvb2xSZXN1bHQSCgoCaWQYASABKAkSDgoGcmVzdWx0GAIgASgJEhMKC2N1c3RvbV9raW5kGAMgASgJEgwKBG5hbWUYBCABKAkiFgoIVG9vbERvbmUSCgoCaWQYASABKAlCQlpAZ2l0aHViLmNvbS9nby1nby1nb2xlbXMvcGlub2NjaGlvL3BrZy9zZW0vcGIvcHJvdG8vc2VtL2Jhc2U7YmFzZWIGcHJvdG8z", [file_google_protobuf_struct]);
 
 /**
  * @generated from message sem.base.tool.ToolStart
@@ -84,6 +84,13 @@ export type ToolResult = Message<"sem.base.tool.ToolResult"> & {
    * @generated from field: string custom_kind = 3;
    */
   customKind: string;
+
+  /**
+   * optional: tool name for cleaner downstream projection/rendering
+   *
+   * @generated from field: string name = 4;
+   */
+  name: string;
 };
 
 /**

--- a/web/src/sem/pb/proto/sem/timeline/tool_pb.ts
+++ b/web/src/sem/pb/proto/sem/timeline/tool_pb.ts
@@ -11,7 +11,7 @@ import type { JsonObject, Message } from "@bufbuild/protobuf";
  * Describes the file proto/sem/timeline/tool.proto.
  */
 export const file_proto_sem_timeline_tool: GenFile = /*@__PURE__*/
-  fileDesc("Ch1wcm90by9zZW0vdGltZWxpbmUvdG9vbC5wcm90bxIMc2VtLnRpbWVsaW5lIpIBChJUb29sQ2FsbFNuYXBzaG90VjESFgoOc2NoZW1hX3ZlcnNpb24YASABKA0SDAoEbmFtZRgCIAEoCRImCgVpbnB1dBgDIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3QSDgoGc3RhdHVzGAQgASgJEhAKCHByb2dyZXNzGAUgASgBEgwKBGRvbmUYBiABKAgipQEKFFRvb2xSZXN1bHRTbmFwc2hvdFYxEhYKDnNjaGVtYV92ZXJzaW9uGAEgASgNEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRInCgZyZXN1bHQYAyABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Eg0KBWVycm9yGAQgASgJEhIKCnJlc3VsdF9yYXcYBSABKAkSEwoLY3VzdG9tX2tpbmQYBiABKAlCSlpIZ2l0aHViLmNvbS9nby1nby1nb2xlbXMvcGlub2NjaGlvL3BrZy9zZW0vcGIvcHJvdG8vc2VtL3RpbWVsaW5lO3RpbWVsaW5lYgZwcm90bzM", [file_google_protobuf_struct]);
+  fileDesc("Ch1wcm90by9zZW0vdGltZWxpbmUvdG9vbC5wcm90bxIMc2VtLnRpbWVsaW5lIpIBChJUb29sQ2FsbFNuYXBzaG90VjESFgoOc2NoZW1hX3ZlcnNpb24YASABKA0SDAoEbmFtZRgCIAEoCRImCgVpbnB1dBgDIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3QSDgoGc3RhdHVzGAQgASgJEhAKCHByb2dyZXNzGAUgASgBEgwKBGRvbmUYBiABKAgiswEKFFRvb2xSZXN1bHRTbmFwc2hvdFYxEhYKDnNjaGVtYV92ZXJzaW9uGAEgASgNEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRInCgZyZXN1bHQYAyABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0Eg0KBWVycm9yGAQgASgJEhIKCnJlc3VsdF9yYXcYBSABKAkSEwoLY3VzdG9tX2tpbmQYBiABKAkSDAoEbmFtZRgHIAEoCUJKWkhnaXRodWIuY29tL2dvLWdvLWdvbGVtcy9waW5vY2NoaW8vcGtnL3NlbS9wYi9wcm90by9zZW0vdGltZWxpbmU7dGltZWxpbmViBnByb3RvMw", [file_google_protobuf_struct]);
 
 /**
  * ToolCallSnapshotV1 defines the payload for a 'tool_call' entity.
@@ -112,6 +112,13 @@ export type ToolResultSnapshotV1 = Message<"sem.timeline.ToolResultSnapshotV1"> 
    * @generated from field: string custom_kind = 6;
    */
   customKind: string;
+
+  /**
+   * Optional: tool name for cleaner downstream projection/rendering.
+   *
+   * @generated from field: string name = 7;
+   */
+  name: string;
 };
 
 /**


### PR DESCRIPTION
This change adds an optional `name` field to the `ToolResult` message in both
the `sem.base` and `sem.timeline` protobuf schemas. This simplifies downstream
processing by including the tool's name directly with its result.

Key changes:
-   Adds an optional `name` string field to `ToolResult` and
    `ToolResultSnapshotV1` protobuf messages.
-   Updates the `SemTranslator` to populate this new field. It tracks active
    tool calls and uses the `tool_call_id` from the result event to look up
    and embed the corresponding tool name.