### PR TITLE
feat(web-chat): Add conversation export

### DIFF
--- a/cmd/web-chat/agentmode_chat_feature.go
+++ b/cmd/web-chat/agentmode_chat_feature.go
@@ -109,7 +109,7 @@ func (agentModePlugin) ProjectTimeline(_ context.Context, ev sessionstream.Event
 		Analysis:  payload.GetAnalysis(),
 		Preview:   false,
 	}
-	return []sessionstream.TimelineEntity{{Kind: agentModeTimelineEntityKind, Id: "session", Payload: entity}}, true, nil
+	return []sessionstream.TimelineEntity{{Kind: agentModeTimelineEntityKind, Id: payload.GetMessageId(), Payload: entity}}, true, nil
 }
 
 func eventStringData(data map[string]interface{}, key string) string {

--- a/cmd/web-chat/app/server.go
+++ b/cmd/web-chat/app/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	chatapp "github.com/go-go-golems/pinocchio/pkg/chatapp"
+	chatexport "github.com/go-go-golems/pinocchio/pkg/chatapp/export"
 	infruntime "github.com/go-go-golems/pinocchio/pkg/inference/runtime"
 	chatstore "github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
 	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
@@ -33,6 +34,8 @@ type Server struct {
 	sqliteDBPath    string
 	runtimeResolver RuntimeResolver
 	turnStore       chatstore.TurnStore
+	turnsDBPath     string
+	exportService   *chatexport.Service
 	chatPlugins     []chatapp.ChatPlugin
 	closeFn         func() error
 }
@@ -88,6 +91,15 @@ func WithTurnStore(store chatstore.TurnStore) Option {
 	}
 }
 
+func WithTurnsDBPath(path string) Option {
+	return func(s *Server) {
+		if s == nil {
+			return
+		}
+		s.turnsDBPath = strings.TrimSpace(path)
+	}
+}
+
 func WithChatPlugins(features ...chatapp.ChatPlugin) Option {
 	return func(s *Server) {
 		if s == nil {
@@ -140,6 +152,7 @@ func NewServer(opts ...Option) (*Server, error) {
 	}
 
 	s.service = service
+	s.exportService = chatexport.NewService(service, chatexport.WithTurnStore(s.turnStore), chatexport.WithTurnsDBPath(s.turnsDBPath))
 	s.ws = ws
 	s.closeFn = cleanup
 	return s, nil
@@ -235,6 +248,18 @@ func (s *Server) HandleSessionRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 	if action == "messages" {
 		s.handleSubmitMessage(w, r, sid)
+		return
+	}
+	if action == "timeline" {
+		s.handleTimelineExport(w, r, sid)
+		return
+	}
+	if action == "turns" {
+		s.handleTurnsExport(w, r, sid)
+		return
+	}
+	if action == "export" {
+		s.handleFullExport(w, r, sid)
 		return
 	}
 	writeJSON(w, http.StatusNotFound, errorResponse{Error: "not found"})

--- a/cmd/web-chat/app/server_export.go
+++ b/cmd/web-chat/app/server_export.go
@@ -92,10 +92,11 @@ func (s *Server) handleFullExport(w http.ResponseWriter, r *http.Request, sid se
 func parseExportOptions(r *http.Request, defaultView chatexport.TimelineView) (chatexport.Options, error) {
 	query := r.URL.Query()
 	opts := chatexport.Options{
-		Format:    chatexport.Format(query.Get("format")),
-		View:      chatexport.TimelineView(query.Get("view")),
-		Download:  query.Get("download") == "true" || query.Get("download") == "1",
-		TurnPhase: query.Get("phase"),
+		Format:     chatexport.Format(query.Get("format")),
+		View:       chatexport.TimelineView(query.Get("view")),
+		Download:   query.Get("download") == "true" || query.Get("download") == "1",
+		TurnPhase:  query.Get("phase"),
+		LatestOnly: true,
 	}
 	if opts.View == "" {
 		opts.View = defaultView

--- a/cmd/web-chat/app/server_export.go
+++ b/cmd/web-chat/app/server_export.go
@@ -1,0 +1,167 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	chatexport "github.com/go-go-golems/pinocchio/pkg/chatapp/export"
+	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
+)
+
+type fullExportResponse struct {
+	SessionID string                     `json:"session_id" yaml:"session_id"`
+	Timeline  *chatexport.TimelineExport `json:"timeline,omitempty" yaml:"timeline,omitempty"`
+	Turns     *chatexport.TurnsExport    `json:"turns,omitempty" yaml:"turns,omitempty"`
+}
+
+func (s *Server) handleTimelineExport(w http.ResponseWriter, r *http.Request, sid sessionstream.SessionId) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	opts, err := parseExportOptions(r, chatexport.TimelineViewEntities)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	if opts.Format == chatexport.FormatMinitrace {
+		writeExportError(w, chatexport.ErrInvalidFormat)
+		return
+	}
+	exported, err := s.exportService.ExportTimeline(r.Context(), string(sid), opts)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	writeRenderedExport(w, r, exported, opts.Format, fmt.Sprintf("pinocchio-%s-timeline", sid))
+}
+
+func (s *Server) handleTurnsExport(w http.ResponseWriter, r *http.Request, sid sessionstream.SessionId) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	opts, err := parseExportOptions(r, chatexport.TimelineViewEntities)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	var exported any
+	if opts.Format == chatexport.FormatMinitrace {
+		exported, err = s.exportService.ExportTurnsMinitrace(r.Context(), string(sid), opts)
+	} else {
+		exported, err = s.exportService.ExportTurns(r.Context(), string(sid), opts)
+	}
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	writeRenderedExport(w, r, exported, opts.Format, fmt.Sprintf("pinocchio-%s-turns", sid))
+}
+
+func (s *Server) handleFullExport(w http.ResponseWriter, r *http.Request, sid sessionstream.SessionId) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	opts, err := parseExportOptions(r, chatexport.TimelineViewEntities)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	if opts.Format == chatexport.FormatMinitrace {
+		writeExportError(w, chatexport.ErrInvalidFormat)
+		return
+	}
+	timeline, err := s.exportService.ExportTimeline(r.Context(), string(sid), opts)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	turns, err := s.exportService.ExportTurns(r.Context(), string(sid), opts)
+	if err != nil && !errors.Is(err, chatexport.ErrTurnStoreUnavailable) {
+		writeExportError(w, err)
+		return
+	}
+	payload := fullExportResponse{SessionID: string(sid), Timeline: timeline, Turns: turns}
+	writeRenderedExport(w, r, payload, opts.Format, fmt.Sprintf("pinocchio-%s-export", sid))
+}
+
+func parseExportOptions(r *http.Request, defaultView chatexport.TimelineView) (chatexport.Options, error) {
+	query := r.URL.Query()
+	opts := chatexport.Options{
+		Format:    chatexport.Format(query.Get("format")),
+		View:      chatexport.TimelineView(query.Get("view")),
+		Download:  query.Get("download") == "true" || query.Get("download") == "1",
+		TurnPhase: query.Get("phase"),
+	}
+	if opts.View == "" {
+		opts.View = defaultView
+	}
+	return opts.Normalized()
+}
+
+func writeRenderedExport(w http.ResponseWriter, r *http.Request, payload any, format chatexport.Format, filenameBase string) {
+	rendered, err := chatexport.Render(payload, format)
+	if err != nil {
+		writeExportError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", rendered.ContentType)
+	if shouldDownload(r) {
+		filename := sanitizeDownloadFilename(filenameBase) + rendered.Extension
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(rendered.Body)
+}
+
+func writeExportError(w http.ResponseWriter, err error) {
+	status := exportHTTPStatus(err)
+	writeJSON(w, status, errorResponse{Error: err.Error()})
+}
+
+func exportHTTPStatus(err error) int {
+	switch {
+	case errors.Is(err, chatexport.ErrInvalidFormat), errors.Is(err, chatexport.ErrInvalidView):
+		return http.StatusBadRequest
+	case errors.Is(err, chatexport.ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, chatexport.ErrTurnsDBPathRequired):
+		return http.StatusConflict
+	case errors.Is(err, chatexport.ErrSnapshotUnavailable), errors.Is(err, chatexport.ErrTurnStoreUnavailable):
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func shouldDownload(r *http.Request) bool {
+	value := r.URL.Query().Get("download")
+	return value == "true" || value == "1"
+}
+
+func sanitizeDownloadFilename(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "export"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/cmd/web-chat/app/server_test.go
+++ b/cmd/web-chat/app/server_test.go
@@ -288,6 +288,30 @@ func TestTimelineExportJSONDownload(t *testing.T) {
 	require.Len(t, payload["entities"], 2)
 }
 
+func TestTurnsExportMinitraceWithFileBackedDB(t *testing.T) {
+	turnsDBPath := filepath.Join(t.TempDir(), "turns.db")
+	turnStore, err := chatstore.NewSQLiteTurnStore(turnsDBPath)
+	require.NoError(t, err)
+	defer func() { _ = turnStore.Close() }()
+	turn := &turns.Turn{ID: "turn-1"}
+	turns.AppendBlock(turn, turns.NewUserTextBlock("pinocchio minitrace export"))
+	payload, err := serde.ToYAML(turn, serde.Options{})
+	require.NoError(t, err)
+	require.NoError(t, turnStore.Save(context.Background(), "sess-minitrace", "sess-minitrace", "turn-1", "final", 1000, string(payload), chatstore.TurnSaveOptions{RuntimeKey: "gpt-5-mini"}))
+
+	_, httpSrv := newTestMux(t, WithTurnStore(turnStore), WithTurnsDBPath(turnsDBPath))
+	resp, err := http.Get(httpSrv.URL + "/api/chat/sessions/sess-minitrace/turns?format=minitrace&download=true")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	require.Contains(t, resp.Header.Get("Content-Disposition"), "pinocchio-sess-minitrace-turns.minitrace.json")
+	var mt map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&mt))
+	require.Equal(t, "minitrace-v0.2.0", mt["schema_version"])
+	require.Equal(t, "pinocchio-turns-sqlite-v1", mt["provenance"].(map[string]any)["source_format"])
+}
+
 func TestTurnsExportYAMLAndMinitraceMissingPath(t *testing.T) {
 	_, httpSrv := newTestMux(t, WithTurnStore(&fakeTurnStore{snapshot: &chatstore.TurnSnapshot{
 		ConvID:      "sess-turn-export",

--- a/cmd/web-chat/app/server_test.go
+++ b/cmd/web-chat/app/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -263,6 +264,79 @@ func TestSubmitAndSnapshot_WiresSessionIDAndTurnStoreIntoRuntime(t *testing.T) {
 	require.Equal(t, "follow up", seenTurn.Blocks[2].Payload[turns.PayloadKeyText])
 }
 
+func TestTimelineExportJSONDownload(t *testing.T) {
+	_, httpSrv := newTestMux(t)
+
+	body := []byte(`{"prompt":"export this timeline","profile":"gpt-5-nano-low"}`)
+	resp, err := http.Post(httpSrv.URL+"/api/chat/sessions/sess-export-1/messages", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	waitForFinishedSnapshot(t, httpSrv.URL, "sess-export-1")
+
+	exportResp, err := http.Get(httpSrv.URL + "/api/chat/sessions/sess-export-1/timeline?format=json&view=entities&download=true")
+	require.NoError(t, err)
+	defer func() { _ = exportResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, exportResp.StatusCode)
+	require.Equal(t, "application/json", exportResp.Header.Get("Content-Type"))
+	require.Contains(t, exportResp.Header.Get("Content-Disposition"), "pinocchio-sess-export-1-timeline.json")
+
+	var payload map[string]any
+	require.NoError(t, json.NewDecoder(exportResp.Body).Decode(&payload))
+	require.Equal(t, "sess-export-1", payload["session_id"])
+	require.Equal(t, "entities", payload["view"])
+	require.Len(t, payload["entities"], 2)
+}
+
+func TestTurnsExportYAMLAndMinitraceMissingPath(t *testing.T) {
+	_, httpSrv := newTestMux(t, WithTurnStore(&fakeTurnStore{snapshot: &chatstore.TurnSnapshot{
+		ConvID:      "sess-turn-export",
+		SessionID:   "sess-turn-export",
+		TurnID:      "turn-1",
+		Phase:       "final",
+		RuntimeKey:  "runtime-a",
+		CreatedAtMs: 1000,
+		Payload:     "id: turn-1\n",
+	}}))
+
+	yamlResp, err := http.Get(httpSrv.URL + "/api/chat/sessions/sess-turn-export/turns?format=yaml&download=true")
+	require.NoError(t, err)
+	defer func() { _ = yamlResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, yamlResp.StatusCode)
+	require.Equal(t, "application/x-yaml", yamlResp.Header.Get("Content-Type"))
+	require.Contains(t, yamlResp.Header.Get("Content-Disposition"), "pinocchio-sess-turn-export-turns.yaml")
+	yamlBody, err := io.ReadAll(yamlResp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(yamlBody), "turn_id: turn-1")
+	require.Contains(t, string(yamlBody), "runtime_key: runtime-a")
+
+	minitraceResp, err := http.Get(httpSrv.URL + "/api/chat/sessions/sess-turn-export/turns?format=minitrace&download=true")
+	require.NoError(t, err)
+	defer func() { _ = minitraceResp.Body.Close() }()
+	require.Equal(t, http.StatusConflict, minitraceResp.StatusCode)
+}
+
+func TestFullExportOmitsTurnsWhenStoreUnavailable(t *testing.T) {
+	_, httpSrv := newTestMux(t)
+
+	body := []byte(`{"prompt":"export bundle","profile":"gpt-5-nano-low"}`)
+	resp, err := http.Post(httpSrv.URL+"/api/chat/sessions/sess-full-export/messages", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	waitForFinishedSnapshot(t, httpSrv.URL, "sess-full-export")
+
+	exportResp, err := http.Get(httpSrv.URL + "/api/chat/sessions/sess-full-export/export?format=json")
+	require.NoError(t, err)
+	defer func() { _ = exportResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, exportResp.StatusCode)
+	var payload map[string]any
+	require.NoError(t, json.NewDecoder(exportResp.Body).Decode(&payload))
+	require.Equal(t, "sess-full-export", payload["session_id"])
+	require.Contains(t, payload, "timeline")
+	require.NotContains(t, payload, "turns")
+}
+
 func TestSQLiteSnapshotPersistsAcrossRestart(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "evtstream-web-chat.db")
 	serverA, httpSrvA := newTestMux(t, WithSQLiteDBPath(dbPath))
@@ -319,6 +393,25 @@ func TestSQLiteSnapshotPersistsAcrossRestart(t *testing.T) {
 	}
 	require.True(t, foundAssistant)
 	require.True(t, foundUser)
+}
+
+func waitForFinishedSnapshot(t *testing.T, baseURL string, sessionID string) SessionSnapshotResponse {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snapResp, err := http.Get(baseURL + "/api/chat/sessions/" + sessionID)
+		require.NoError(t, err)
+		var snap SessionSnapshotResponse
+		require.NoError(t, json.NewDecoder(snapResp.Body).Decode(&snap))
+		_ = snapResp.Body.Close()
+		if snap.Status == "finished" {
+			return snap
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for finished snapshot; last status=%q", snap.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 type fakeTurnStore struct {

--- a/cmd/web-chat/main.go
+++ b/cmd/web-chat/main.go
@@ -368,6 +368,7 @@ func (c *Command) RunIntoWriter(ctx context.Context, parsed *values.Values, _ io
 		appserver.WithSQLiteDBPath(s.TimelineDB),
 		appserver.WithRuntimeResolver(canonicalRuntimeResolver),
 		appserver.WithTurnStore(turnStore),
+		appserver.WithTurnsDBPath(s.TurnsDB),
 		appserver.WithChatPlugins(newAgentModePlugin(), plugins.NewReasoningPlugin(), plugins.NewToolCallPlugin()),
 	)
 	if err != nil {

--- a/cmd/web-chat/web/src/webchat/components/ExportMenu.tsx
+++ b/cmd/web-chat/web/src/webchat/components/ExportMenu.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useRef, useState } from 'react';
+import { useAppSelector } from '../../store/hooks';
+import { basePrefixFromLocation } from '../../utils/basePrefix';
+
+export function ExportMenu() {
+  const convId = useAppSelector((s: { app: { convId: string } }) => s.app.convId);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+  const close = useCallback(() => setOpen(false), []);
+
+  const downloadUrl = useCallback(
+    (suffix: string) => {
+      if (!convId) return '#';
+      const base = basePrefixFromLocation();
+      return `${base}/api/chat/sessions/${encodeURIComponent(convId)}${suffix}`;
+    },
+    [convId],
+  );
+
+  if (!convId) return null;
+
+  return (
+    <div
+      data-part="export-menu"
+      ref={ref}
+      style={{ position: 'relative', display: 'inline-block' }}
+    >
+      <button
+        type="button"
+        data-part="pill-button"
+        onClick={toggle}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        Export ▾
+      </button>
+      {open ? (
+        <>
+          <div
+            data-part="export-backdrop"
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 998,
+            }}
+            onClick={close}
+          />
+          <div
+            data-part="export-dropdown"
+            style={{
+              position: 'absolute',
+              right: 0,
+              top: '100%',
+              marginTop: 4,
+              zIndex: 999,
+              padding: '4px 0',
+              background: 'var(--pwchat-surface-1, #fff)',
+              border: '1px solid var(--pwchat-border, #ddd)',
+              borderRadius: 6,
+              minWidth: 220,
+              boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
+            }}
+          >
+            <ExportItem
+              label="Timeline JSON"
+              href={downloadUrl('/timeline?format=json&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Timeline YAML"
+              href={downloadUrl('/timeline?format=yaml&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Turns JSON"
+              href={downloadUrl('/turns?format=json&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Turns YAML"
+              href={downloadUrl('/turns?format=yaml&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Turns Minitrace"
+              href={downloadUrl('/turns?format=minitrace&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Full Export (JSON)"
+              href={downloadUrl('/export?format=json&download=true')}
+              close={close}
+            />
+            <ExportItem
+              label="Full Export (YAML)"
+              href={downloadUrl('/export?format=yaml&download=true')}
+              close={close}
+            />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function ExportItem({
+  label,
+  href,
+  close,
+}: {
+  label: string;
+  href: string;
+  close: () => void;
+}) {
+  return (
+    <div>
+      <a
+        href={href}
+        download
+        onClick={close}
+        style={{
+          display: 'block',
+          padding: '6px 14px',
+          color: 'var(--pwchat-fg, #222)',
+          textDecoration: 'none',
+          fontSize: 13,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </a>
+    </div>
+  );
+}

--- a/cmd/web-chat/web/src/webchat/components/Statusbar.tsx
+++ b/cmd/web-chat/web/src/webchat/components/Statusbar.tsx
@@ -1,6 +1,7 @@
 import { getPartProps, mergeClassName, mergeStyle } from '../parts';
 import type { StatusbarSlotProps } from '../types';
 import { fmtShort } from '../utils';
+import { ExportMenu } from './ExportMenu';
 
 export function DefaultStatusbar(props: StatusbarSlotProps) {
   const {
@@ -49,6 +50,7 @@ export function DefaultStatusbar(props: StatusbarSlotProps) {
       <span data-part="pill">seq: {fmtShort(lastSeq)}</span>
       <span data-part="pill">q: {fmtShort(queueDepth)}</span>
       <span data-part="pill">{status}</span>
+      <ExportMenu />
       {errorCount > 0 ? (
         <button
           type="button"

--- a/pkg/chatapp/export/minitrace.go
+++ b/pkg/chatapp/export/minitrace.go
@@ -1,0 +1,586 @@
+package export
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+const (
+	minitraceSchemaVersion    = "minitrace-v0.2.0"
+	minitraceSourceFormat     = "pinocchio-turns-sqlite-v1"
+	minitraceConverterVersion = "pinocchio-chatapp-export-dev"
+	minitraceTruncateLimit    = 10 * 1024
+
+	minitracePayloadKeyArgs   = "args"
+	minitracePayloadKeyError  = "error"
+	minitracePayloadKeyID     = "id"
+	minitracePayloadKeyName   = "name"
+	minitracePayloadKeyResult = "result"
+	minitracePayloadKeyText   = "text"
+)
+
+var minitracePhasePreference = []string{"final", "post_tools", "post_inference", "pre_inference"}
+
+type minitraceSnapshotSummary struct {
+	ConvID              string
+	SessionID           string
+	TurnID              string
+	TurnCreatedAtMS     int64
+	RuntimeKey          string
+	InferenceID         string
+	Phase               string
+	SnapshotCreatedAtMS int64
+}
+
+type minitraceBlock struct {
+	ID       string
+	Kind     string
+	Role     string
+	Payload  map[string]any
+	Metadata map[string]any
+}
+
+type minitraceCanonicalSnapshot struct {
+	minitraceSnapshotSummary
+	Blocks []minitraceBlock
+}
+
+func (s *Service) ExportTurnsMinitrace(ctx context.Context, sessionID string, _ Options) (any, error) {
+	if s == nil || strings.TrimSpace(s.turnsDBPath) == "" {
+		return nil, ErrTurnsDBPathRequired
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errors.Wrap(ErrNotFound, "session id is empty")
+	}
+	session, err := convertTurnsDBToMinitrace(ctx, s.turnsDBPath, sessionID, s.formatNow())
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+func convertTurnsDBToMinitrace(ctx context.Context, dbPath string, convID string, exportedAt string) (map[string]any, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, errors.Wrap(ErrNotFound, "stat turns db")
+	}
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", dbPath))
+	if err != nil {
+		return nil, errors.Wrap(err, "open turns db")
+	}
+	defer func() { _ = db.Close() }()
+
+	snapshots, err := loadMinitraceCanonicalSnapshots(ctx, db, convID)
+	if err != nil {
+		return nil, err
+	}
+	if len(snapshots) == 0 {
+		return nil, ErrNotFound
+	}
+	return buildMinitraceSession(convID, dbPath, exportedAt, snapshots), nil
+}
+
+func loadMinitraceCanonicalSnapshots(ctx context.Context, db *sql.DB, convID string) ([]minitraceCanonicalSnapshot, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+		  t.conv_id,
+		  t.session_id,
+		  t.turn_id,
+		  t.turn_created_at_ms,
+		  COALESCE(t.runtime_key, '') AS runtime_key,
+		  COALESCE(t.inference_id, '') AS inference_id,
+		  m.phase,
+		  m.snapshot_created_at_ms
+		FROM turns t
+		JOIN turn_block_membership m
+		  ON m.conv_id = t.conv_id
+		 AND m.session_id = t.session_id
+		 AND m.turn_id = t.turn_id
+		WHERE t.conv_id = ?
+		GROUP BY
+		  t.conv_id,
+		  t.session_id,
+		  t.turn_id,
+		  t.turn_created_at_ms,
+		  t.runtime_key,
+		  t.inference_id,
+		  m.phase,
+		  m.snapshot_created_at_ms
+		ORDER BY t.turn_created_at_ms ASC, t.session_id ASC, t.turn_id ASC, m.snapshot_created_at_ms ASC
+	`, convID)
+	if err != nil {
+		return nil, errors.Wrap(err, "query minitrace snapshot summaries")
+	}
+	defer func() { _ = rows.Close() }()
+
+	grouped := map[string][]minitraceSnapshotSummary{}
+	for rows.Next() {
+		var s minitraceSnapshotSummary
+		if err := rows.Scan(&s.ConvID, &s.SessionID, &s.TurnID, &s.TurnCreatedAtMS, &s.RuntimeKey, &s.InferenceID, &s.Phase, &s.SnapshotCreatedAtMS); err != nil {
+			return nil, errors.Wrap(err, "scan minitrace snapshot summary")
+		}
+		key := s.ConvID + "\x00" + s.SessionID + "\x00" + s.TurnID
+		grouped[key] = append(grouped[key], s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "iterate minitrace snapshot summaries")
+	}
+
+	keys := make([]string, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left := grouped[keys[i]][0]
+		right := grouped[keys[j]][0]
+		if left.TurnCreatedAtMS != right.TurnCreatedAtMS {
+			return left.TurnCreatedAtMS < right.TurnCreatedAtMS
+		}
+		if left.SessionID != right.SessionID {
+			return left.SessionID < right.SessionID
+		}
+		return left.TurnID < right.TurnID
+	})
+
+	out := make([]minitraceCanonicalSnapshot, 0, len(keys))
+	for _, key := range keys {
+		summary := chooseMinitraceSummary(grouped[key])
+		blocks, err := loadMinitraceBlocks(ctx, db, summary)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, minitraceCanonicalSnapshot{minitraceSnapshotSummary: summary, Blocks: blocks})
+	}
+	return out, nil
+}
+
+func chooseMinitraceSummary(summaries []minitraceSnapshotSummary) minitraceSnapshotSummary {
+	for _, phase := range minitracePhasePreference {
+		var selected *minitraceSnapshotSummary
+		for i := range summaries {
+			if summaries[i].Phase != phase {
+				continue
+			}
+			if selected == nil || summaries[i].SnapshotCreatedAtMS > selected.SnapshotCreatedAtMS {
+				selected = &summaries[i]
+			}
+		}
+		if selected != nil {
+			return *selected
+		}
+	}
+	selected := summaries[0]
+	for _, summary := range summaries[1:] {
+		if summary.SnapshotCreatedAtMS > selected.SnapshotCreatedAtMS {
+			selected = summary
+		}
+	}
+	return selected
+}
+
+func loadMinitraceBlocks(ctx context.Context, db *sql.DB, summary minitraceSnapshotSummary) ([]minitraceBlock, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+		  b.block_id,
+		  b.kind,
+		  b.role,
+		  COALESCE(b.payload_json, '{}') AS payload_json,
+		  COALESCE(b.block_metadata_json, '{}') AS block_metadata_json
+		FROM turn_block_membership m
+		JOIN blocks b
+		  ON b.block_id = m.block_id
+		 AND b.content_hash = m.content_hash
+		WHERE m.conv_id = ?
+		  AND m.session_id = ?
+		  AND m.turn_id = ?
+		  AND m.phase = ?
+		  AND m.snapshot_created_at_ms = ?
+		ORDER BY m.ordinal ASC
+	`, summary.ConvID, summary.SessionID, summary.TurnID, summary.Phase, summary.SnapshotCreatedAtMS)
+	if err != nil {
+		return nil, errors.Wrap(err, "query minitrace blocks")
+	}
+	defer func() { _ = rows.Close() }()
+
+	blocks := []minitraceBlock{}
+	for rows.Next() {
+		var block minitraceBlock
+		var payloadJSON, metadataJSON string
+		if err := rows.Scan(&block.ID, &block.Kind, &block.Role, &payloadJSON, &metadataJSON); err != nil {
+			return nil, errors.Wrap(err, "scan minitrace block")
+		}
+		block.Payload = parseJSONMap(payloadJSON)
+		block.Metadata = parseJSONMap(metadataJSON)
+		blocks = append(blocks, block)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "iterate minitrace blocks")
+	}
+	return blocks, nil
+}
+
+func buildMinitraceSession(convID string, sourcePath string, exportedAt string, snapshots []minitraceCanonicalSnapshot) map[string]any {
+	turns := []map[string]any{}
+	toolCalls := []map[string]any{}
+	annotations := []map[string]any{}
+	timestamps := []time.Time{}
+	modelsSeen := []string{}
+	previous := []minitraceBlock{}
+
+	for _, snapshot := range snapshots {
+		timestamp := formatMillis(snapshot.TurnCreatedAtMS)
+		if timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339, timestamp); err == nil {
+				timestamps = append(timestamps, ts)
+			}
+		}
+		if snapshot.RuntimeKey != "" {
+			modelsSeen = append(modelsSeen, snapshot.RuntimeKey)
+		}
+		delta := minitraceDelta(previous, snapshot.Blocks)
+		previous = snapshot.Blocks
+
+		reasoning := []string{}
+		startTurnIndex := len(turns)
+		for _, block := range delta {
+			text := stringifyMinitracePayload(block.Payload)
+			if block.Kind == "reasoning" {
+				if strings.TrimSpace(text) != "" {
+					reasoning = append(reasoning, text)
+				}
+				continue
+			}
+			role, source, inputChannel := classifyMinitraceBlock(block)
+			if role == "" {
+				continue
+			}
+			turn := map[string]any{
+				"index":              len(turns),
+				"timestamp":          nilIfEmpty(timestamp),
+				"role":               role,
+				"source":             nilIfEmpty(source),
+				"model":              nilIfEmpty(snapshot.RuntimeKey),
+				"content_type":       nil,
+				"input_channel":      nilIfEmpty(inputChannel),
+				"content":            text,
+				"framework_metadata": map[string]any{"pinocchio_kind": block.Kind, "original_role": block.Role, "turn_id": snapshot.TurnID, "phase": snapshot.Phase, "session_id": snapshot.SessionID},
+				"tool_calls_in_turn": []string{},
+				"thinking":           nil,
+				"intent_markers":     nil,
+				"streaming":          map[string]any{"was_streamed": false, "stream_log": nil},
+				"usage":              nil,
+			}
+			if len(reasoning) > 0 && role == "assistant" {
+				turn["thinking"] = strings.Join(reasoning, "\n\n")
+				reasoning = nil
+			}
+			turns = append(turns, turn)
+		}
+		emittingTurn := -1
+		if len(turns) > 0 && len(turns)-1 >= startTurnIndex {
+			emittingTurn = len(turns) - 1
+		}
+		deltaTools, deltaAnnotations := buildMinitraceToolCalls(delta, timestamp, emittingTurn)
+		toolCalls = append(toolCalls, deltaTools...)
+		annotations = append(annotations, deltaAnnotations...)
+	}
+
+	startedAt, endedAt, duration := minitraceTiming(timestamps)
+	model := ""
+	if len(modelsSeen) > 0 {
+		model = modelsSeen[len(modelsSeen)-1]
+	}
+	quality := "C"
+	if len(turns) > 0 {
+		quality = "B"
+	}
+	if len(turns) > 5 && len(toolCalls) > 10 {
+		quality = "A"
+	}
+
+	return map[string]any{
+		"id":                  convID,
+		"schema_version":      minitraceSchemaVersion,
+		"profile":             "organic",
+		"scenario_id":         nil,
+		"quality":             quality,
+		"title":               minitraceTitle(turns),
+		"summary":             nil,
+		"classification":      "internal",
+		"provenance":          map[string]any{"source_format": minitraceSourceFormat, "source_path": sourcePath, "converted_at": exportedAt, "converter_version": minitraceConverterVersion, "original_session_id": convID},
+		"flags":               map[string]any{"for_research": false, "needs_cleaning": true, "contains_error": false, "contains_pii": strings.Contains(sourcePath, "/home/") || strings.Contains(sourcePath, "/Users/"), "category": []string{}},
+		"environment":         map[string]any{"model": nilIfEmpty(model), "model_version": nil, "temperature": nil, "tools_enabled": minitraceToolNames(toolCalls), "system_prompt": nil, "agent_framework": "pinocchio", "agent_version": nil, "platform_type": "agent", "provider_hint": providerHint(model)},
+		"operational_context": map[string]any{"working_directory": nil, "git_branch": nil, "git_ref": nil, "autonomy_level": nil, "sandbox": nil, "framework_config": nil},
+		"timing":              map[string]any{"privacy_level": "full", "duration_seconds": duration, "active_duration_seconds": duration, "started_at": startedAt, "ended_at": endedAt, "hour_of_day": hourOfDay(startedAt), "day_of_week": dayOfWeek(startedAt)},
+		"condition":           nil,
+		"coordination":        map[string]any{"project_id": nil, "predecessor_session": nil, "concurrent_sessions": nil, "human_attention": "unknown"},
+		"handover":            map[string]any{"received": nil, "produced": nil},
+		"turns":               turns,
+		"tool_calls":          toolCalls,
+		"outcome":             nil,
+		"annotations":         annotations,
+		"metrics":             minitraceMetrics(turns, toolCalls, duration),
+	}
+}
+
+func minitraceDelta(previous, current []minitraceBlock) []minitraceBlock {
+	seen := map[string]int{}
+	for _, block := range previous {
+		seen[minitraceBlockFingerprint(block)]++
+	}
+	out := []minitraceBlock{}
+	for _, block := range current {
+		fp := minitraceBlockFingerprint(block)
+		if seen[fp] > 0 {
+			seen[fp]--
+			continue
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+func minitraceBlockFingerprint(block minitraceBlock) string {
+	payload, _ := json.Marshal(block.Payload)
+	metadata, _ := json.Marshal(block.Metadata)
+	return fmt.Sprintf("%s|%s|%s|%s|%s", block.Kind, block.Role, block.ID, payload, metadata)
+}
+
+func classifyMinitraceBlock(block minitraceBlock) (string, string, string) {
+	switch block.Kind {
+	case "llm_text":
+		return "assistant", "model", ""
+	case "system":
+		return "system", "system", "system_prompt"
+	case "user":
+		return "user", "human", "user_input"
+	default:
+		return "", "", ""
+	}
+}
+
+func buildMinitraceToolCalls(blocks []minitraceBlock, timestamp string, emittingTurn int) ([]map[string]any, []map[string]any) {
+	toolCalls := []map[string]any{}
+	annotations := []map[string]any{}
+	pending := map[string]int{}
+	for _, block := range blocks {
+		switch block.Kind {
+		case "tool_call":
+			id := firstNonEmpty(stringValue(block.Payload[minitracePayloadKeyID]), fmt.Sprintf("tool-call-%d", len(toolCalls)))
+			turnIndex := any(nil)
+			if emittingTurn >= 0 {
+				turnIndex = emittingTurn
+			}
+			call := map[string]any{
+				"id":                  id,
+				"emitting_turn_index": turnIndex,
+				"timestamp":           nilIfEmpty(timestamp),
+				"tool_name":           firstNonEmpty(stringValue(block.Payload[minitracePayloadKeyName]), "unknown"),
+				"operation_type":      "EXECUTE",
+				"input":               map[string]any{"file_path": nil, "command": nil, "justification": nil, "arguments": block.Payload[minitracePayloadKeyArgs]},
+				"output":              map[string]any{"success": false, "result": nil, "error": nil, "exit_code": nil, "duration_ms": nil, "truncated": false, "full_bytes": nil, "full_hash": nil, "full_reference": nil, "redacted": nil, "content_origin": "local_exec"},
+				"context":             map[string]any{"position_in_session": nil, "tools_before": []string{}, "time_since_last_user": nil},
+				"framework_metadata":  map[string]any{"pinocchio_kind": block.Kind, "payload": block.Payload},
+				"spawned_agent":       nil,
+			}
+			pending[id] = len(toolCalls)
+			toolCalls = append(toolCalls, call)
+		case "tool_use":
+			id := stringValue(block.Payload[minitracePayloadKeyID])
+			idx, ok := pending[id]
+			if !ok {
+				annotations = append(annotations, minitraceAnnotation(fmt.Sprintf("ann-tool-use-orphan-%d", len(annotations)), "session", "session", "observation", "Orphan tool_use block", stringifyAny(block.Payload), []string{"pinocchio", "tool_use", "orphan"}))
+				continue
+			}
+			output := toolCalls[idx]["output"].(map[string]any)
+			errorText := stringValue(block.Payload[minitracePayloadKeyError])
+			result, fullBytes, fullHash := truncateMinitraceContent(stringifyAny(block.Payload[minitracePayloadKeyResult]))
+			output["success"] = strings.TrimSpace(errorText) == ""
+			output["result"] = result
+			output["truncated"] = fullBytes != nil
+			output["full_bytes"] = fullBytes
+			output["full_hash"] = fullHash
+			if strings.TrimSpace(errorText) != "" {
+				output["error"] = errorText
+			}
+			delete(pending, id)
+		}
+	}
+	for id, idx := range pending {
+		toolCalls[idx]["output"].(map[string]any)["error"] = "no tool result received"
+		annotations = append(annotations, minitraceAnnotation(fmt.Sprintf("ann-tool-call-pending-%d", len(annotations)), "tool_call", id, "observation", "Tool call never received result", id, []string{"pinocchio", "tool_call", "orphan"}))
+	}
+	return toolCalls, annotations
+}
+
+func minitraceAnnotation(id, scopeType, targetID, category, title, detail string, tags []string) map[string]any {
+	return map[string]any{"id": id, "timestamp": time.Now().UTC().Format(time.RFC3339), "annotator": "adapter", "scope": map[string]any{"type": scopeType, "target_id": targetID}, "content": map[string]any{"category": category, "tags": tags, "title": title, "detail": detail}, "taxonomy_mappings": map[string]any{"minitrace": []string{}, "mast": []string{}, "toolemu": []string{}}, "classification": nil}
+}
+
+func minitraceTiming(timestamps []time.Time) (any, any, any) {
+	if len(timestamps) == 0 {
+		return nil, nil, nil
+	}
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i].Before(timestamps[j]) })
+	start := timestamps[0].UTC().Format(time.RFC3339)
+	end := timestamps[len(timestamps)-1].UTC().Format(time.RFC3339)
+	duration := timestamps[len(timestamps)-1].Sub(timestamps[0]).Seconds()
+	return start, end, duration
+}
+
+func minitraceMetrics(turns []map[string]any, toolCalls []map[string]any, duration any) map[string]any {
+	return map[string]any{"turn_count": len(turns), "tool_call_count": len(toolCalls), "read_count": 0, "modify_count": 0, "create_count": 0, "execute_count": len(toolCalls), "delegate_count": 0, "read_ratio": nil, "time_to_first_action": nil, "idle_ratio": nil, "total_input_tokens": nil, "total_output_tokens": nil, "total_cache_read_tokens": nil, "total_cache_creation_tokens": nil, "total_reasoning_tokens": nil, "total_tool_tokens": nil, "session_cost": nil, "subagent_count": 0, "subagent_tool_calls": 0, "duration_seconds": duration}
+}
+
+func minitraceToolNames(toolCalls []map[string]any) []string {
+	seen := map[string]struct{}{}
+	for _, call := range toolCalls {
+		if name := stringValue(call["tool_name"]); name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func minitraceTitle(turns []map[string]any) any {
+	for _, turn := range turns {
+		if turn["role"] != "user" {
+			continue
+		}
+		text := strings.TrimSpace(stringValue(turn["content"]))
+		if text == "" {
+			continue
+		}
+		if len(text) > 80 {
+			return text[:77] + "..."
+		}
+		return text
+	}
+	return nil
+}
+
+func providerHint(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.HasPrefix(model, "gpt-"):
+		return "openai"
+	case strings.HasPrefix(model, "cerebras-"):
+		return "cerebras"
+	default:
+		return "unknown"
+	}
+}
+
+func hourOfDay(value any) any {
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return nil
+	}
+	ts, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		return nil
+	}
+	return ts.Hour()
+}
+
+func dayOfWeek(value any) any {
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return nil
+	}
+	ts, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		return nil
+	}
+	weekday := int(ts.Weekday()) - 1
+	if weekday < 0 {
+		weekday = 6
+	}
+	return weekday
+}
+
+func truncateMinitraceContent(value string) (any, *int, *string) {
+	if len(value) <= minitraceTruncateLimit {
+		return value, nil, nil
+	}
+	fullBytes := len(value)
+	sum := sha256.Sum256([]byte(value))
+	hash := hex.EncodeToString(sum[:])
+	truncated := value[:minitraceTruncateLimit]
+	return truncated, &fullBytes, &hash
+}
+
+func parseJSONMap(raw string) map[string]any {
+	out := map[string]any{}
+	if strings.TrimSpace(raw) == "" {
+		return out
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func stringifyMinitracePayload(payload map[string]any) string {
+	if text := stringValue(payload[minitracePayloadKeyText]); strings.TrimSpace(text) != "" {
+		return text
+	}
+	return stringifyAny(payload)
+}
+
+func stringifyAny(value any) string {
+	if value == nil {
+		return ""
+	}
+	if text, ok := value.(string); ok {
+		return text
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(body)
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nilIfEmpty(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}

--- a/pkg/chatapp/export/render.go
+++ b/pkg/chatapp/export/render.go
@@ -1,0 +1,50 @@
+package export
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type Rendered struct {
+	Body        []byte
+	ContentType string
+	Extension   string
+}
+
+func Render(value any, format Format) (Rendered, error) {
+	switch NormalizeFormat(format) {
+	case "", FormatJSON, FormatMinitrace:
+		body, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return Rendered{}, errors.Wrap(err, "render json export")
+		}
+		return Rendered{Body: append(body, '\n'), ContentType: "application/json", Extension: extensionForFormat(format)}, nil
+	case FormatYAML:
+		body, err := yaml.Marshal(value)
+		if err != nil {
+			return Rendered{}, errors.Wrap(err, "render yaml export")
+		}
+		return Rendered{Body: body, ContentType: "application/x-yaml", Extension: ".yaml"}, nil
+	case FormatMarkdown:
+		return Rendered{}, errors.Wrap(ErrInvalidFormat, "markdown rendering is not implemented yet")
+	default:
+		return Rendered{}, ErrInvalidFormat
+	}
+}
+
+func extensionForFormat(format Format) string {
+	switch NormalizeFormat(format) {
+	case FormatJSON, "":
+		return ".json"
+	case FormatMinitrace:
+		return ".minitrace.json"
+	case FormatYAML:
+		return ".yaml"
+	case FormatMarkdown:
+		return ".md"
+	default:
+		return ".json"
+	}
+}

--- a/pkg/chatapp/export/service.go
+++ b/pkg/chatapp/export/service.go
@@ -150,13 +150,6 @@ func (s *Service) ExportTurns(ctx context.Context, sessionID string, opts Option
 	return out, nil
 }
 
-func (s *Service) ExportTurnsMinitrace(context.Context, string, Options) (any, error) {
-	if s == nil || strings.TrimSpace(s.turnsDBPath) == "" {
-		return nil, ErrTurnsDBPathRequired
-	}
-	return nil, errors.New("minitrace export converter is not wired yet")
-}
-
 func (s *Service) formatNow() string {
 	now := time.Now
 	if s != nil && s.now != nil {

--- a/pkg/chatapp/export/service.go
+++ b/pkg/chatapp/export/service.go
@@ -128,6 +128,9 @@ func (s *Service) ExportTurns(ctx context.Context, sessionID string, opts Option
 		}
 		return turns[i].TurnID < turns[j].TurnID
 	})
+	if normalized.LatestOnly && len(turns) > 0 {
+		turns = turns[len(turns)-1:]
+	}
 	out := &TurnsExport{
 		SessionID:  sessionID,
 		Phase:      normalized.TurnPhase,

--- a/pkg/chatapp/export/service.go
+++ b/pkg/chatapp/export/service.go
@@ -1,0 +1,188 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	chatstore "github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
+	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type SnapshotProvider interface {
+	Snapshot(ctx context.Context, sid sessionstream.SessionId) (sessionstream.Snapshot, error)
+}
+
+type Service struct {
+	snapshotProvider SnapshotProvider
+	turnStore        chatstore.TurnStore
+	turnsDBPath      string
+	now              func() time.Time
+}
+
+type Option func(*Service)
+
+func NewService(snapshotProvider SnapshotProvider, opts ...Option) *Service {
+	s := &Service{snapshotProvider: snapshotProvider, now: time.Now}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(s)
+		}
+	}
+	return s
+}
+
+func WithTurnStore(store chatstore.TurnStore) Option {
+	return func(s *Service) {
+		if s != nil {
+			s.turnStore = store
+		}
+	}
+}
+
+func WithTurnsDBPath(path string) Option {
+	return func(s *Service) {
+		if s != nil {
+			s.turnsDBPath = strings.TrimSpace(path)
+		}
+	}
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) {
+		if s != nil && now != nil {
+			s.now = now
+		}
+	}
+}
+
+func (s *Service) ExportTimeline(ctx context.Context, sessionID string, opts Options) (*TimelineExport, error) {
+	if s == nil || s.snapshotProvider == nil {
+		return nil, ErrSnapshotUnavailable
+	}
+	normalized, err := opts.Normalized()
+	if err != nil {
+		return nil, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errors.Wrap(ErrNotFound, "session id is empty")
+	}
+
+	snap, err := s.snapshotProvider.Snapshot(ctx, sessionstream.SessionId(sessionID))
+	if err != nil {
+		return nil, err
+	}
+	out := &TimelineExport{
+		SessionID:       string(snap.SessionId),
+		SnapshotOrdinal: snap.SnapshotOrdinal,
+		View:            normalized.View,
+		ExportedAt:      s.formatNow(),
+		Entities:        make([]EntityExport, 0, len(snap.Entities)),
+	}
+	for _, entity := range snap.Entities {
+		payload, err := protoToExportValue(entity.Payload)
+		if err != nil {
+			payload = map[string]any{"error": err.Error()}
+		}
+		out.Entities = append(out.Entities, EntityExport{
+			Kind:             entity.Kind,
+			ID:               entity.Id,
+			CreatedOrdinal:   entity.CreatedOrdinal,
+			LastEventOrdinal: entity.LastEventOrdinal,
+			Tombstone:        entity.Tombstone,
+			Payload:          payload,
+		})
+	}
+	return out, nil
+}
+
+func (s *Service) ExportTurns(ctx context.Context, sessionID string, opts Options) (*TurnsExport, error) {
+	if s == nil || s.turnStore == nil {
+		return nil, ErrTurnStoreUnavailable
+	}
+	normalized, err := opts.Normalized()
+	if err != nil {
+		return nil, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errors.Wrap(ErrNotFound, "session id is empty")
+	}
+	turns, err := s.turnStore.List(ctx, chatstore.TurnQuery{
+		ConvID: sessionID,
+		Phase:  normalized.TurnPhase,
+		Limit:  normalized.Limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(turns, func(i, j int) bool {
+		if turns[i].CreatedAtMs != turns[j].CreatedAtMs {
+			return turns[i].CreatedAtMs < turns[j].CreatedAtMs
+		}
+		return turns[i].TurnID < turns[j].TurnID
+	})
+	out := &TurnsExport{
+		SessionID:  sessionID,
+		Phase:      normalized.TurnPhase,
+		ExportedAt: s.formatNow(),
+		Turns:      make([]TurnSnapshotExport, 0, len(turns)),
+	}
+	for _, turn := range turns {
+		out.Turns = append(out.Turns, TurnSnapshotExport{
+			ConvID:      turn.ConvID,
+			SessionID:   turn.SessionID,
+			TurnID:      turn.TurnID,
+			Phase:       turn.Phase,
+			RuntimeKey:  turn.RuntimeKey,
+			InferenceID: turn.InferenceID,
+			CreatedAtMs: turn.CreatedAtMs,
+			CreatedAt:   formatMillis(turn.CreatedAtMs),
+			Payload:     turn.Payload,
+		})
+	}
+	return out, nil
+}
+
+func (s *Service) ExportTurnsMinitrace(context.Context, string, Options) (any, error) {
+	if s == nil || strings.TrimSpace(s.turnsDBPath) == "" {
+		return nil, ErrTurnsDBPathRequired
+	}
+	return nil, errors.New("minitrace export converter is not wired yet")
+}
+
+func (s *Service) formatNow() string {
+	now := time.Now
+	if s != nil && s.now != nil {
+		now = s.now
+	}
+	return now().UTC().Format(time.RFC3339)
+}
+
+func formatMillis(ms int64) string {
+	if ms <= 0 {
+		return ""
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}
+
+func protoToExportValue(msg proto.Message) (any, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	body, err := protojson.MarshalOptions{EmitUnpopulated: false, UseProtoNames: true}.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/chatapp/export/service_test.go
+++ b/pkg/chatapp/export/service_test.go
@@ -3,9 +3,12 @@ package export
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/serde"
 	chatstore "github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
 	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
 	"github.com/stretchr/testify/require"
@@ -69,6 +72,35 @@ func TestExportTurnsMinitraceRequiresFileBackedDBPath(t *testing.T) {
 	svc := NewService(nil)
 	_, err := svc.ExportTurnsMinitrace(context.Background(), "session-1", Options{})
 	require.ErrorIs(t, err, ErrTurnsDBPathRequired)
+}
+
+func TestExportTurnsMinitraceFromFileBackedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "turns.db")
+	store, err := chatstore.NewSQLiteTurnStore(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	turn := &turns.Turn{ID: "turn-1"}
+	turns.AppendBlock(turn, turns.NewUserTextBlock("hello minitrace"))
+	turns.AppendBlock(turn, turns.NewAssistantTextBlock("hello back"))
+	payload, err := serde.ToYAML(turn, serde.Options{})
+	require.NoError(t, err)
+	require.NoError(t, store.Save(context.Background(), "session-1", "session-1", "turn-1", "final", 1000, string(payload), chatstore.TurnSaveOptions{RuntimeKey: "gpt-5-mini"}))
+
+	svc := NewService(nil, WithTurnsDBPath(dbPath), WithClock(fixedClock))
+	raw, err := svc.ExportTurnsMinitrace(context.Background(), "session-1", Options{})
+	require.NoError(t, err)
+	session, ok := raw.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "session-1", session["id"])
+	require.Equal(t, "minitrace-v0.2.0", session["schema_version"])
+	require.Equal(t, "B", session["quality"])
+	require.Equal(t, "hello minitrace", session["title"])
+	require.Equal(t, "pinocchio-turns-sqlite-v1", session["provenance"].(map[string]any)["source_format"])
+	require.Equal(t, "pinocchio", session["environment"].(map[string]any)["agent_framework"])
+	require.Equal(t, "openai", session["environment"].(map[string]any)["provider_hint"])
+	require.Len(t, session["turns"], 2)
+	require.Equal(t, 2, session["metrics"].(map[string]any)["turn_count"])
 }
 
 func TestRenderJSONAndYAML(t *testing.T) {

--- a/pkg/chatapp/export/service_test.go
+++ b/pkg/chatapp/export/service_test.go
@@ -1,0 +1,128 @@
+package export
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	chatstore "github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
+	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestExportTimelineEntities(t *testing.T) {
+	payload, err := structpb.NewStruct(map[string]any{"text": "hello", "count": float64(3)})
+	require.NoError(t, err)
+	provider := fakeSnapshotProvider{snap: sessionstream.Snapshot{
+		SessionId:       "session-1",
+		SnapshotOrdinal: 42,
+		Entities: []sessionstream.TimelineEntity{{
+			Kind:             "ChatMessage",
+			Id:               "msg-1",
+			CreatedOrdinal:   1,
+			LastEventOrdinal: 2,
+			Payload:          payload,
+		}},
+	}}
+	svc := NewService(provider, WithClock(fixedClock))
+
+	exported, err := svc.ExportTimeline(context.Background(), "session-1", Options{View: TimelineViewEntities})
+	require.NoError(t, err)
+	require.Equal(t, "session-1", exported.SessionID)
+	require.Equal(t, uint64(42), exported.SnapshotOrdinal)
+	require.Equal(t, "2026-05-06T12:00:00Z", exported.ExportedAt)
+	require.Len(t, exported.Entities, 1)
+	require.Equal(t, "ChatMessage", exported.Entities[0].Kind)
+	require.Equal(t, "msg-1", exported.Entities[0].ID)
+	require.Equal(t, uint64(1), exported.Entities[0].CreatedOrdinal)
+	require.Equal(t, uint64(2), exported.Entities[0].LastEventOrdinal)
+	require.Equal(t, map[string]any{"count": float64(3), "text": "hello"}, exported.Entities[0].Payload)
+}
+
+func TestExportTurnsSortsOldestFirst(t *testing.T) {
+	store := &fakeTurnStore{items: []chatstore.TurnSnapshot{
+		{ConvID: "session-1", SessionID: "session-1", TurnID: "turn-new", Phase: "final", RuntimeKey: "runtime-b", CreatedAtMs: 2000, Payload: "id: turn-new\n"},
+		{ConvID: "session-1", SessionID: "session-1", TurnID: "turn-old", Phase: "final", RuntimeKey: "runtime-a", CreatedAtMs: 1000, Payload: "id: turn-old\n"},
+	}}
+	svc := NewService(nil, WithTurnStore(store), WithClock(fixedClock))
+
+	exported, err := svc.ExportTurns(context.Background(), "session-1", Options{})
+	require.NoError(t, err)
+	require.Equal(t, chatstore.TurnQuery{ConvID: "session-1", Phase: "final", Limit: 1000}, store.lastQuery)
+	require.Equal(t, "session-1", exported.SessionID)
+	require.Equal(t, "final", exported.Phase)
+	require.Len(t, exported.Turns, 2)
+	require.Equal(t, "turn-old", exported.Turns[0].TurnID)
+	require.Equal(t, "1970-01-01T00:00:01Z", exported.Turns[0].CreatedAt)
+	require.Equal(t, "turn-new", exported.Turns[1].TurnID)
+}
+
+func TestExportTurnsRequiresStore(t *testing.T) {
+	svc := NewService(nil)
+	_, err := svc.ExportTurns(context.Background(), "session-1", Options{})
+	require.ErrorIs(t, err, ErrTurnStoreUnavailable)
+}
+
+func TestExportTurnsMinitraceRequiresFileBackedDBPath(t *testing.T) {
+	svc := NewService(nil)
+	_, err := svc.ExportTurnsMinitrace(context.Background(), "session-1", Options{})
+	require.ErrorIs(t, err, ErrTurnsDBPathRequired)
+}
+
+func TestRenderJSONAndYAML(t *testing.T) {
+	value := map[string]any{"session_id": "session-1"}
+
+	jsonRendered, err := Render(value, FormatJSON)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", jsonRendered.ContentType)
+	require.Equal(t, ".json", jsonRendered.Extension)
+	require.Contains(t, string(jsonRendered.Body), `"session_id": "session-1"`)
+
+	yamlRendered, err := Render(value, FormatYAML)
+	require.NoError(t, err)
+	require.Equal(t, "application/x-yaml", yamlRendered.ContentType)
+	require.Equal(t, ".yaml", yamlRendered.Extension)
+	require.Contains(t, string(yamlRendered.Body), "session_id: session-1")
+}
+
+func fixedClock() time.Time {
+	return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+}
+
+type fakeSnapshotProvider struct {
+	snap sessionstream.Snapshot
+	err  error
+}
+
+func (f fakeSnapshotProvider) Snapshot(context.Context, sessionstream.SessionId) (sessionstream.Snapshot, error) {
+	if f.err != nil {
+		return sessionstream.Snapshot{}, f.err
+	}
+	return f.snap, nil
+}
+
+type fakeTurnStore struct {
+	items     []chatstore.TurnSnapshot
+	err       error
+	lastQuery chatstore.TurnQuery
+}
+
+func (f *fakeTurnStore) Save(context.Context, string, string, string, string, int64, string, chatstore.TurnSaveOptions) error {
+	return nil
+}
+
+func (f *fakeTurnStore) List(_ context.Context, q chatstore.TurnQuery) ([]chatstore.TurnSnapshot, error) {
+	f.lastQuery = q
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]chatstore.TurnSnapshot(nil), f.items...), nil
+}
+
+func (f *fakeTurnStore) LoadLatestTurn(context.Context, string, string) (*chatstore.TurnSnapshot, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeTurnStore) Close() error { return nil }

--- a/pkg/chatapp/export/types.go
+++ b/pkg/chatapp/export/types.go
@@ -1,0 +1,130 @@
+package export
+
+import (
+	"errors"
+	"strings"
+)
+
+type Format string
+
+const (
+	FormatJSON      Format = "json"
+	FormatYAML      Format = "yaml"
+	FormatMarkdown  Format = "markdown"
+	FormatMinitrace Format = "minitrace"
+)
+
+type TimelineView string
+
+const (
+	TimelineViewMessages TimelineView = "messages"
+	TimelineViewEntities TimelineView = "entities"
+	TimelineViewTurns    TimelineView = "turns"
+)
+
+var (
+	ErrInvalidFormat        = errors.New("invalid export format")
+	ErrInvalidView          = errors.New("invalid timeline export view")
+	ErrSnapshotUnavailable  = errors.New("snapshot provider unavailable")
+	ErrTurnStoreUnavailable = errors.New("turn store unavailable")
+	ErrTurnsDBPathRequired  = errors.New("minitrace export requires a file-backed turns database")
+	ErrNotFound             = errors.New("export source not found")
+)
+
+type Options struct {
+	Format          Format
+	View            TimelineView
+	Download        bool
+	TurnPhase       string
+	Limit           int
+	IncludeTimeline bool
+	IncludeTurns    bool
+}
+
+func (o Options) Normalized() (Options, error) {
+	out := o
+	out.Format = NormalizeFormat(out.Format)
+	if out.Format == "" {
+		out.Format = FormatJSON
+	}
+	if !out.Format.Valid() {
+		return out, ErrInvalidFormat
+	}
+	out.View = NormalizeTimelineView(out.View)
+	if out.View == "" {
+		out.View = TimelineViewEntities
+	}
+	if !out.View.Valid() {
+		return out, ErrInvalidView
+	}
+	out.TurnPhase = strings.TrimSpace(out.TurnPhase)
+	if out.TurnPhase == "" {
+		out.TurnPhase = "final"
+	}
+	if out.Limit <= 0 {
+		out.Limit = 1000
+	}
+	return out, nil
+}
+
+func NormalizeFormat(format Format) Format {
+	return Format(strings.ToLower(strings.TrimSpace(string(format))))
+}
+
+func (f Format) Valid() bool {
+	switch NormalizeFormat(f) {
+	case FormatJSON, FormatYAML, FormatMarkdown, FormatMinitrace:
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeTimelineView(view TimelineView) TimelineView {
+	return TimelineView(strings.ToLower(strings.TrimSpace(string(view))))
+}
+
+func (v TimelineView) Valid() bool {
+	switch NormalizeTimelineView(v) {
+	case TimelineViewMessages, TimelineViewEntities, TimelineViewTurns:
+		return true
+	default:
+		return false
+	}
+}
+
+type TimelineExport struct {
+	SessionID       string         `json:"session_id" yaml:"session_id"`
+	SnapshotOrdinal uint64         `json:"snapshot_ordinal" yaml:"snapshot_ordinal"`
+	View            TimelineView   `json:"view" yaml:"view"`
+	ExportedAt      string         `json:"exported_at" yaml:"exported_at"`
+	Entities        []EntityExport `json:"entities,omitempty" yaml:"entities,omitempty"`
+}
+
+type EntityExport struct {
+	Kind             string `json:"kind" yaml:"kind"`
+	ID               string `json:"id" yaml:"id"`
+	CreatedOrdinal   uint64 `json:"created_ordinal" yaml:"created_ordinal"`
+	LastEventOrdinal uint64 `json:"last_event_ordinal" yaml:"last_event_ordinal"`
+	Tombstone        bool   `json:"tombstone" yaml:"tombstone"`
+	Payload          any    `json:"payload,omitempty" yaml:"payload,omitempty"`
+}
+
+type TurnsExport struct {
+	SessionID  string               `json:"session_id" yaml:"session_id"`
+	Phase      string               `json:"phase" yaml:"phase"`
+	ExportedAt string               `json:"exported_at" yaml:"exported_at"`
+	Turns      []TurnSnapshotExport `json:"turns" yaml:"turns"`
+}
+
+type TurnSnapshotExport struct {
+	ConvID      string `json:"conv_id" yaml:"conv_id"`
+	SessionID   string `json:"session_id" yaml:"session_id"`
+	TurnID      string `json:"turn_id" yaml:"turn_id"`
+	Phase       string `json:"phase" yaml:"phase"`
+	RuntimeKey  string `json:"runtime_key,omitempty" yaml:"runtime_key,omitempty"`
+	InferenceID string `json:"inference_id,omitempty" yaml:"inference_id,omitempty"`
+	CreatedAtMs int64  `json:"created_at_ms" yaml:"created_at_ms"`
+	CreatedAt   string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	Payload     string `json:"payload" yaml:"payload"`
+}

--- a/pkg/chatapp/export/types.go
+++ b/pkg/chatapp/export/types.go
@@ -37,6 +37,7 @@ type Options struct {
 	Download        bool
 	TurnPhase       string
 	Limit           int
+	LatestOnly      bool
 	IncludeTimeline bool
 	IncludeTurns    bool
 }

--- a/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/changelog.md
+++ b/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-05-07
+
+- Initial workspace created

--- a/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/design/01-streaming-pipeline-investigation-and-debug-guide.md
+++ b/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/design/01-streaming-pipeline-investigation-and-debug-guide.md
@@ -1,0 +1,1020 @@
+# Streaming Pipeline Investigation and Debug Guide
+
+This document explains every layer of the Pinocchio web-chat streaming pipeline in enough detail for a new intern to understand the data flow, identify where things can go wrong, and build tools that surface discrepancies between what the backend emitted and what the frontend rendered.
+
+It is organized as a walk from the user's "Submit" button all the way down to the Redux store and back up to the screen. Each section explains what the code does, why it does it that way, where the common failure modes are, and what a debug tool should capture at that layer.
+
+---
+
+## Table of Contents
+
+1. [The Big Picture](#the-big-picture)
+2. [Layer 1: The Submit Button and the Inference Request](#layer-1-the-submit-button-and-the-inference-request)
+3. [Layer 2: The Chatapp Engine and Backend Event Emission](#layer-2-the-chatapp-engine-and-backend-event-emission)
+4. [Layer 3: The SessionStream Service](#layer-3-the-sessionstream-service)
+5. [Layer 4: WebSocket Transport](#layer-4-websocket-transport)
+6. [Layer 5: Frontend Frame Parsing](#layer-5-frontend-frame-parsing)
+7. [Layer 6: Hydration and Snapshot Application](#layer-6-hydration-and-snapshot-application)
+8. [Layer 7: UI Event Projection and Timeline Mutation](#layer-7-ui-event-projection-and-timeline-mutation)
+9. [Layer 8: Redux State and Entity Ordering](#layer-8-redux-state-and-entity-ordering)
+10. [Layer 9: Rendering](#layer-9-rendering)
+11. [What Can Go Wrong: A Failure Mode Catalog](#what-can-go-wrong-a-failure-mode-catalog)
+12. [Backend Event Recording Design](#backend-event-recording-design)
+13. [Frontend Debug Mode Design](#frontend-debug-mode-design)
+14. [Reconciliation and Comparison Tools](#reconciliation-and-comparison-tools)
+15. [Test Scenarios](#test-scenarios)
+16. [File Reference](#file-reference)
+17. [API Reference](#api-reference)
+
+---
+
+## The Big Picture
+
+When a user types a prompt and presses Enter in the Pinocchio web-chat, a chain of transformations begins. The prompt travels from the browser to a Go backend. The backend runs inference through a Geppetto engine. As the model generates tokens, the backend publishes events. Those events flow through a sessionstream service, which projects them into UI events and persists timeline entities. The UI events travel over a WebSocket to the browser. The browser parses them, updates a Redux store, and React renders the result.
+
+The key insight is that there are **four distinct representations** of the same conversation at any given moment:
+
+1. **Backend events** — the raw emissions from the inference engine and feature plugins.
+2. **Timeline entities** — the persisted, durable state that survives page reloads.
+3. **UI events** — the ephemeral signals that tell the frontend what changed.
+4. **Redux entities** — the in-browser state that React renders.
+
+A bug can appear when any of these representations diverge from the others. The most common symptom is: "I sent a prompt, the model replied, but after reload something is missing or in the wrong order."
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Inference   │────>│  Backend     │────>│  Session     │
+│   Engine      │     │  Events      │     │  Stream      │
+│  (Geppetto)   │     │  (protobuf)  │     │  Service     │
+└──────────────┘     └──────────────┘     └──────┬───────┘
+                                                  │
+                                     ┌────────────┴────────────┐
+                                     │                         │
+                               ┌─────▼─────┐           ┌──────▼─────┐
+                               │  Timeline  │           │  UI Events │
+                               │  Entities  │           │  (ephemeral)│
+                               │  (durable) │           └──────┬─────┘
+                               └─────┬─────┘                  │
+                                     │              ┌─────────▼─────────┐
+                                     │              │   WebSocket       │
+                                     │              │   Transport       │
+                                     │              └─────────┬─────────┘
+                                     │                        │
+                               ┌─────▼─────┐          ┌──────▼──────┐
+                               │  Snapshot  │◄─────────│  Frontend   │
+                               │  (hydrate) │          │  Parser     │
+                               └─────┬─────┘          └──────┬──────┘
+                                     │                        │
+                               ┌─────▼─────┐          ┌──────▼──────┐
+                               │  Redux     │◄─────────│  Timeline   │
+                               │  Store     │          │  Slice      │
+                               └─────┬─────┘          └─────────────┘
+                                     │
+                               ┌─────▼─────┐
+                               │  React     │
+                               │  Render    │
+                               └───────────┘
+```
+
+Every arrow in this diagram is a place where things can go wrong. The debug tools this ticket creates will instrument every arrow.
+
+## Layer 1: The Submit Button and the Inference Request
+
+When the user types text into the composer and presses Enter (or clicks Send), the `ChatWidget` component in `cmd/web-chat/web/src/webchat/ChatWidget.tsx` runs its `send` callback. This callback does three things in sequence:
+
+1. **Ensures a session exists.** If there is no `convId` in the Redux `app` slice, it calls `POST /api/chat/sessions` to create one. The server returns `{ sessionId: "..." }` which the frontend stores in Redux and writes to the URL query string via `window.history.replaceState`.
+
+2. **Ensures the WebSocket is connected.** It calls `wsManager.connect(...)` with the session ID. If the WebSocket is already open for the same session, this is a no-op. Otherwise, it opens a new connection and subscribes.
+
+3. **Posts the prompt.** It calls `POST /api/chat/sessions/${sessionId}/messages` with a JSON body `{ prompt, profile }`. The server acknowledges with `{ status: "running" }`.
+
+The important thing to notice is that the prompt submission is a **regular HTTP POST**, not a WebSocket message. The WebSocket is used only for receiving streaming responses. This design means the prompt path and the response path are separate transports, which has implications for debugging: a prompt can succeed (200 OK) even if the WebSocket is disconnected, and vice versa.
+
+```typescript
+// Simplified from ChatWidget.tsx send()
+const res = await fetch(`${basePrefix}/api/chat/sessions/${sessionId}/messages`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ prompt, profile: selectedProfile }),
+});
+```
+
+**What can go wrong here:**
+
+- The session creation POST fails (network error, server down). The user sees an error in the error panel but the WebSocket may already be connecting.
+- The WebSocket connects before the session is created, causing a subscribe for an empty session ID.
+- The prompt POST returns 200 but the backend never publishes events because the runtime resolver returned an error that was swallowed.
+- The profile selector shows a stale profile if the profile mutation is still in flight.
+
+**What the debug tool should capture:**
+
+- Timestamp of the submit button press.
+- The session ID used (newly created or existing).
+- The prompt text.
+- The HTTP response status and body from the POST.
+
+## Layer 2: The Chatapp Engine and Backend Event Emission
+
+The HTTP handler for `POST /sessions/{id}/messages` calls `chatapp.Engine.SubmitPrompt()`. The engine is defined in `pkg/chatapp/chat.go`. Its job is to:
+
+1. Accept the prompt text and resolve a runtime (Geppetto engine + turn store persister + history loader).
+2. Create or load a Geppetto session with the conversation history.
+3. Run inference in a goroutine.
+4. Publish backend events as the inference progresses.
+
+The engine publishes events by calling `e.publish(ctx, sid, pub, eventName, payload)`. The `pub` function is a sessionstream event publisher that wraps `sessionstream.Service.PublishBackendEvent()`. Each event has:
+
+- A **session ID** (which session this event belongs to).
+- An **event name** (e.g., `ChatInferenceStarted`, `ChatMessageAppended`, `ChatReasoningFinished`).
+- A **payload** (a protobuf message, e.g., `ChatMessageUpdate`, `ReasoningUpdate`).
+- An **ordinal** (assigned by the sessionstream service, strictly increasing per session).
+
+The core inference loop looks like this (simplified):
+
+```go
+// In chatapp/chat.go, runRuntimeInference()
+e.publish(ctx, sid, pub, EventInferenceStarted, started)
+
+for iteration := 0; iteration < maxIterations; iteration++ {
+    result, err := runtime.RunInference(ctx, accumulatedTurn)
+    if err != nil {
+        e.publish(ctx, sid, pub, EventInferenceStopped, stopped)
+        return
+    }
+
+    // Publish streaming text events
+    for _, block := range result.Blocks {
+        if block.Kind == "reasoning" {
+            e.handleFeatureRuntimeEvent(ctx, sid, messageID, pub, reasoningEvent)
+        }
+        // ... tool calls, etc.
+    }
+
+    e.publish(ctx, sid, pub, EventInferenceFinished, finished)
+}
+```
+
+**Feature plugins** sit between the raw Geppetto events and the published backend events. The `ChatPlugin` interface (in `pkg/chatapp/features.go`) has three methods:
+
+- `HandleRuntimeEvent` — translates a Geppetto engine event into one or more published backend events.
+- `ProjectUI` — translates a backend event into UI events for the frontend.
+- `ProjectTimeline` — translates a backend event into durable timeline entities.
+
+The engine calls `HandleRuntimeEvent` on every plugin for every Geppetto event. The first plugin that returns `handled: true` wins — plugins are tried in registration order. This means plugin ordering matters, and a bug in one plugin can silently swallow events that another plugin would have handled.
+
+There are currently three plugins:
+
+| Plugin | File | Handles |
+|--------|------|---------|
+| Reasoning | `pkg/chatapp/plugins/reasoning.go` | `EventReasoningStarted`, `EventReasoningDelta`, `EventReasoningFinished` |
+| ToolCall | `pkg/chatapp/plugins/toolcall.go` | `EventToolCallStarted`, `EventToolCallUpdated`, `EventToolCallFinished`, `EventToolResultReady` |
+| AgentMode | `cmd/web-chat/agentmode_chat_feature.go` | `EventModeSwitchPreview`, `EventAgentModeSwitch` |
+
+Each plugin registers its events, UI events, and timeline entities with the `sessionstream.SchemaRegistry` at startup. The registry maps event names to protobuf message types so the sessionstream service can serialize and deserialize them.
+
+**What can go wrong here:**
+
+- A Geppetto event is not handled by any plugin and becomes a silent drop.
+- A plugin publishes the wrong event name or wrong payload type.
+- The inference loop hits max iterations and publishes a warning `EventInferenceFinished` instead of `EventInferenceStopped`, confusing the frontend.
+- A runtime resolver error is swallowed and only a `stopped` event is published without a corresponding `started` event, leaving the frontend in an inconsistent state.
+- History loading fails and publishes a `stopped` with an error message, but the frontend has already shown a "user message" entity from the local optimistic update.
+
+**What the debug tool should capture:**
+
+- Every backend event published: ordinal, name, payload type, payload JSON.
+- The Geppetto event that triggered each backend event (for traceability).
+- Which plugin handled each event (or whether it was unhandled).
+- Errors from the inference loop, including max-iteration warnings.
+
+## Layer 3: The SessionStream Service
+
+The sessionstream service is a standalone package (`sessionstream/pkg/sessionstream/`) that sits between the chatapp engine and the WebSocket transport. It does three things:
+
+1. **Persists backend events** in an event log (SQLite `sessionstream_events` table). Each event gets a monotonically increasing ordinal per session.
+
+2. **Projects backend events** into two derived streams:
+   - **UI events** — ephemeral signals sent to connected WebSocket clients. Produced by `ProjectUI`.
+   - **Timeline entities** — durable state persisted for hydration. Produced by `ProjectTimeline`.
+
+3. **Manages WebSocket subscriptions** — fans out UI events to all connected clients subscribed to a session.
+
+The projection pipeline works like this:
+
+```
+Backend Event
+    │
+    ├──► UI Projection (Engine.uiProjection)
+    │       ├── base projection (chat messages)
+    │       ├── reasoning plugin
+    │       ├── toolcall plugin
+    │       └── agentmode plugin
+    │       │
+    │       └──► UI Events → WebSocket → Frontend
+    │
+    └──► Timeline Projection (Engine.timelineProjection)
+            ├── base projection (chat message entities)
+            ├── reasoning plugin (chat message entities)
+            ├── toolcall plugin (tool_call, tool_result entities)
+            └── agentmode plugin (AgentMode entities)
+            │
+            └──► Timeline Entities → Hydration Store (SQLite)
+```
+
+A single backend event can produce **multiple** UI events and **multiple** timeline entities. For example, `ChatAgentModeCommitted` produces:
+- 1 UI event: `ChatAgentModeCommitted`
+- 1 UI event: `ChatAgentModePreviewCleared`
+- 1 timeline entity: `AgentMode` (with a unique entity ID based on the message ID)
+
+The UI events and timeline entities are produced independently. They can have different payloads and different shapes. The frontend receives UI events over the WebSocket but hydrates from timeline entities. This means there are **two independent paths** to the same visual state, and they must agree.
+
+**What can go wrong here:**
+
+- A backend event is projected to UI events but not to timeline entities (or vice versa). The live stream looks correct but after reload, the entity is missing.
+- A timeline entity is projected with the wrong entity ID, causing it to overwrite a different entity on upsert.
+- A projection returns an error that is logged but not surfaced to the frontend.
+- The projection cursor (tracking which ordinals have been materialized) gets out of sync, causing events to be skipped or replayed.
+- Two plugins project timeline entities with the same `(kind, id)` key, and the second one silently overwrites the first.
+
+**What the debug tool should capture:**
+
+- Every UI event produced from each backend event: name, payload type, ordinal.
+- Every timeline entity produced from each backend event: kind, ID, created ordinal, payload.
+- Any projection errors.
+- The mapping from backend event ordinal → UI events and timeline entities, so a comparison tool can verify completeness.
+
+## Layer 4: WebSocket Transport
+
+The Go backend serves a WebSocket endpoint at `GET /api/chat/ws`. The sessionstream service manages the WebSocket lifecycle. When a client connects, it receives:
+
+1. A `hello` frame with the server protocol version.
+2. After the client sends a `subscribe` frame with a session ID, it receives:
+   - A `snapshot` frame containing all current timeline entities (the hydration payload).
+   - A `subscribed` confirmation frame.
+3. From then on, every UI event produced by the projection is serialized as a `uiEvent` frame and sent to all subscribed WebSocket connections.
+
+The wire format is **protobuf JSON with oneof wrapper frames**. This is important: the raw JSON on the wire is not a flat event object. It is a wrapper with exactly one field set, corresponding to the protobuf oneof in `sessionstream.proto`. For example:
+
+```json
+{
+  "uiEvent": {
+    "sessionId": "...",
+    "eventOrdinal": "215",
+    "name": "ChatAgentModeCommitted",
+    "payload": {
+      "@type": "type.googleapis.com/pinocchio.chatapp.v1.AgentModeCommittedUpdate",
+      "messageId": "chat-msg-7",
+      "title": "agentmode: mode switched",
+      "from": "financial_analyst",
+      "to": "category_regexp_designer",
+      "analysis": "..."
+    }
+  }
+}
+```
+
+The `payload` field is a `google.protobuf.Any`, which means it has an `@type` field identifying the concrete message type, followed by the message fields. The frontend must parse the `@type` to know which protobuf schema to use.
+
+**What can go wrong here:**
+
+- A WebSocket frame is malformed (missing `@type`, wrong oneof field, non-JSON).
+- A frame is dropped due to a slow consumer (WebSocket backpressure).
+- Multiple tabs subscribe to the same session. Each tab gets its own copy of every UI event. If one tab disconnects and reconnects, it gets a fresh snapshot.
+- The `eventOrdinal` field is a string, not a number. The frontend must parse it carefully.
+- Large payloads (long assistant messages, big tool results) may be split across TCP packets. The WebSocket protocol handles framing, but intermediate proxies or load balancers may not.
+
+**What the debug tool should capture:**
+
+- Every raw WebSocket message received: timestamp, raw string (first 500 chars for large messages).
+- The parsed frame type: `hello`, `snapshot`, `subscribed`, `uiEvent`, `error`, `ping`, `pong`.
+- For `uiEvent` frames: the event ordinal, the event name, the `@type` of the payload.
+- For `snapshot` frames: the snapshot ordinal, the number of entities, the time to process.
+- WebSocket lifecycle events: open, close, error.
+
+## Layer 5: Frontend Frame Parsing
+
+All WebSocket frame parsing happens in `cmd/web-chat/web/src/ws/protocol.ts`. The core function is `parseServerFrame(raw: string): CanonicalFrame`. It:
+
+1. Parses the raw JSON string.
+2. Detects which oneof field is present: `hello`, `snapshot`, `subscribed`, `uiEvent`, `error`, `ping`, `pong`.
+3. Normalizes each into a flat `CanonicalFrame` object with a `type` field.
+
+The normalizer unwraps nested structures. For example, a raw `uiEvent` frame arrives as:
+
+```json
+{
+  "uiEvent": {
+    "sessionId": "...",
+    "eventOrdinal": "215",
+    "name": "ChatMessageAppended",
+    "payload": { "@type": "...", "content": "Hello", "role": "assistant" }
+  }
+}
+```
+
+The normalizer produces:
+
+```typescript
+{
+  type: "ui-event",
+  sessionId: "...",
+  ordinal: 215,
+  name: "ChatMessageAppended",
+  payload: { content: "Hello", role: "assistant" }  // unwrapped from Any
+}
+```
+
+The `unwrapAnyPayload` function handles the `google.protobuf.Any` unwrapping. Concrete protobuf payloads arrive with their fields next to `@type`. Legacy `Struct` payloads arrive as `{ "@type": "...Struct", "value": { ... } }`. The function returns `value` if it exists, otherwise the top-level fields.
+
+This is a critical parsing step. If the unwrap logic is wrong, the entire payload is lost and the UI event becomes a no-op.
+
+**What can go wrong here:**
+
+- A new protobuf message type is added to the backend but the frontend `unwrapAnyPayload` does not handle it correctly.
+- A `Struct` payload has a `value` field that is not an object (e.g., a string or array), causing the unwrap to produce an empty object.
+- The `eventOrdinal` is a large number string that loses precision when parsed as a JavaScript number. The `safeOrdinal` function handles this by checking `Number.isSafeInteger`.
+- The frame has an unexpected oneof field (e.g., a new server sends a frame type the frontend does not know about), and the normalizer returns the raw frame unchanged, which downstream code ignores.
+
+**What the debug tool should capture:**
+
+- Every raw frame and its parsed result side by side.
+- Whether `unwrapAnyPayload` used the `value` path or the top-level path.
+- Any frames where `safeOrdinal` returned `null` (ordinal overflow or parse failure).
+- Any frames where the type was not recognized by the normalizer.
+
+## Layer 6: Hydration and Snapshot Application
+
+When the WebSocket connects and subscribes, the server sends a `snapshot` frame. This frame contains every timeline entity currently persisted for the session. The frontend applies the snapshot by:
+
+1. Clearing the Redux timeline state (`timelineSlice.actions.clear()`).
+2. Iterating over each entity in the snapshot and converting it from the raw protobuf JSON to a frontend `TimelineEntity`.
+3. Upserting each entity into the Redux store.
+
+The conversion happens in `timelineEntityFromSnapshotEntity()` in `wsManager.ts`. This function is the **bridge between the backend's protobuf entity model and the frontend's display model**. It maps backend entity kinds to frontend entity shapes:
+
+| Backend Kind | Frontend Kind | ID Source |
+|-------------|--------------|-----------|
+| `ChatMessage` | `message` | `payload.messageId` or entity ID |
+| `AgentMode` | `agent_mode` | entity ID (now message-based) |
+| — (preview) | `agent_mode_preview` | `agent-mode-preview:{messageId}` |
+
+The function also unwraps the payload. For `AgentMode` entities, it checks whether `payload.data` is a non-empty object (new typed protobuf format) and falls back to extracting `from`, `to`, `analysis` from the top-level payload (old `Struct` format). This dual-path unwrapping is a historical artifact from the typed protobuf migration.
+
+**What can go wrong here:**
+
+- The snapshot entity has a kind the frontend does not recognize. The function returns `null` and the entity is silently dropped.
+- The payload unwrap produces an empty object because neither `data` nor the top-level fields are present.
+- The entity ID is empty or null, causing the function to return `null`.
+- A `ChatMessage` entity has no `messageId` in the payload, so it falls back to the entity ID, which might be wrong for the frontend's entity model.
+- The snapshot is applied, but then buffered UI events are replayed on top of it. If a buffered UI event has a different entity ID for the same logical entity, the result is a duplicate.
+- A second tab connects to the same session and receives a snapshot while the first tab is still streaming. The first tab's live state and the second tab's hydrated state may differ if projections have advanced between the two connections.
+
+**What the debug tool should capture:**
+
+- The raw snapshot frame: number of entities, snapshot ordinal.
+- Each entity in the snapshot: kind, ID, whether `timelineEntityFromSnapshotEntity` returned null (dropped).
+- For each entity: which unwrap path was used (`data` or top-level fields).
+- The number of buffered UI events that were replayed after the snapshot.
+- The time from snapshot receipt to Redux state update complete.
+
+## Layer 7: UI Event Projection and Timeline Mutation
+
+After hydration, every incoming `ui-event` frame is processed by `applyUIEvent()` in `wsManager.ts`. This function calls `timelineMutationFromUIEvent()` to convert the frame into a `TimelineMutation`:
+
+```typescript
+type TimelineMutation = {
+  upsert?: TimelineEntity;   // insert or update an entity
+  deleteId?: string;          // remove an entity
+  status?: string;            // update the app-level status
+};
+```
+
+The `timelineMutationFromUIEvent` function is a large switch statement that maps UI event names to Redux mutations. Here is the complete mapping:
+
+| UI Event Name | Mutation |
+|--------------|----------|
+| `ChatMessageAccepted` | upsert `message` (role=user, status=submitted) |
+| `ChatMessageStarted` | upsert `message` (role=assistant, status=streaming) + status=streaming |
+| `ChatMessageAppended` | upsert `message` (role=assistant, status=streaming) + status=streaming |
+| `ChatMessageFinished` | upsert `message` (role=assistant, status=finished) + status=finished |
+| `ChatMessageStopped` | upsert `message` (role=assistant, status=stopped) + status=stopped |
+| `ChatReasoningStarted` | upsert `message` (role=thinking, status=streaming) + status=streaming |
+| `ChatReasoningAppended` | upsert `message` (role=thinking, status=streaming) + status=streaming |
+| `ChatReasoningFinished` | upsert `message` (role=thinking, status=finished) |
+| `ChatAgentModePreviewUpdated` | upsert `agent_mode_preview` |
+| `ChatAgentModeCommitted` | upsert `agent_mode` |
+| `ChatAgentModePreviewCleared` | delete `agent_mode_preview` |
+
+**Critical detail about entity IDs during live streaming:**
+
+During live streaming, the entity ID used for `upsert` is critical. For `ChatMessageStarted` and `ChatMessageAppended`, the ID is `messageId` from the payload. For `ChatReasoningStarted`, the ID is also `messageId`. This means the reasoning entity and the assistant message entity have **different IDs** — the reasoning block gets its own ID (e.g., `chat-msg-2-thinking`) separate from the assistant message (e.g., `chat-msg-2`).
+
+But during hydration, the backend stores reasoning as a `ChatMessage` entity with `role=thinking` and a different entity ID. The frontend's `timelineEntityFromSnapshotEntity` function maps it to a `message` entity with `role=thinking`. The entity IDs in the snapshot come from the timeline projection, which uses the message ID as the entity ID.
+
+This means there is a **semantic difference** between how live streaming creates entities and how hydration restores them. Live streaming uses the message ID directly. Hydration uses whatever entity ID the timeline projection assigned.
+
+**What can go wrong here:**
+
+- A UI event name is not handled by the switch statement. The mutation returns `null` and the event is silently ignored.
+- The `messageId` is missing from the payload, causing the mutation to return `null`.
+- Two different UI events upsert entities with the same ID but different kinds (e.g., a reasoning entity and an assistant message both using `chat-msg-2`). The second upsert overwrites the first.
+- A `ChatMessageStarted` event has no `content` field, so the upsert is skipped (the function returns only a status mutation). If no subsequent `ChatMessageAppended` event arrives, the assistant message never appears.
+- The `status` mutation sets the app-level status to `streaming` but the corresponding `ChatMessageFinished` event sets it to `finished`. If the finished event is missed (WebSocket disconnect), the app stays in `streaming` forever.
+
+**What the debug tool should capture:**
+
+- Every UI event processed: event name, message ID, ordinal.
+- The resulting mutation: upsert (entity ID, kind, key props), delete, or status change.
+- Any UI events that produced `null` mutations (unhandled events).
+- The current app status after each mutation.
+
+## Layer 8: Redux State and Entity Ordering
+
+The Redux timeline state is defined in `cmd/web-chat/web/src/store/timelineSlice.ts`. It has two fields:
+
+```typescript
+type TimelineState = {
+  byId: Record<string, TimelineEntity>;  // entity ID → entity
+  order: string[];                        // entity IDs in insertion order
+};
+```
+
+The `upsertEntity` reducer is the most important operation. It handles both insert (new entity) and update (existing entity) cases. The ordering rules are:
+
+- **New entity**: Add to `byId` and append ID to `order`.
+- **Existing entity, with version**: If the incoming version is greater than the stored version, replace. If less, ignore. This is the "versioned" path for entities that carry explicit version numbers.
+- **Existing entity, without version**: Merge props, preserve `createdAt`, update `updatedAt`. The entity keeps its position in `order` (no re-ordering).
+
+The `createdAt` field is **never overwritten** by an upsert of an existing entity. This is a deliberate design choice: `createdAt` represents when the entity first appeared, and subsequent updates should not change that.
+
+The `order` array determines the rendering order. Entities are rendered in the order they were first inserted. This means:
+
+1. A tool call entity inserted at ordinal 10 appears before a tool result entity inserted at ordinal 20.
+2. If a tool call completed event arrives at ordinal 21 and upserts the tool call entity, the entity stays at its original position in `order` (position of ordinal 10).
+3. This prevents the bug where a late-arriving update causes a tool call to jump after its result.
+
+**What can go wrong here:**
+
+- An entity is upserted with the wrong ID, creating a duplicate instead of updating the original.
+- The `rekeyEntity` action is used incorrectly, leaving stale IDs in the order array.
+- An entity is deleted but its ID remains in the `order` array (the `deleteEntity` reducer does clean this up, but a custom reducer might not).
+- Two entities with the same ID but different kinds compete for the same slot. The last upsert wins, changing the kind and potentially the renderer.
+- The `order` array grows without bound for long sessions, causing React to re-render the entire timeline on every update.
+
+**What the debug tool should capture:**
+
+- Every Redux action dispatched: type, payload entity ID/kind.
+- The resulting state change: added, updated, or deleted entity; new order length.
+- Any upserts where the incoming version was less than the stored version (ignored stale update).
+- The current `order` array after each mutation, for ordering comparison.
+
+## Layer 9: Rendering
+
+The `ChatTimeline` component in `cmd/web-chat/web/src/webchat/components/Timeline.tsx` renders the timeline. It receives the ordered list of entities from the Redux selector `selectTimelineEntities` and maps each entity to a renderer.
+
+The renderer registry is built in `cmd/web-chat/web/src/webchat/rendererRegistry.ts`. The default renderers are defined in `cmd/web-chat/web/src/webchat/cards.tsx`. The mapping is:
+
+| Entity Kind | Renderer | Visual |
+|------------|----------|--------|
+| `message` (role=user) | UserMessageCard | User bubble with prompt text |
+| `message` (role=assistant) | AssistantMessageCard | Assistant bubble with response text |
+| `message` (role=thinking) | ThinkingCard | Collapsible reasoning block |
+| `agent_mode` | AgentModeCard | Mode switch indicator with analysis bullets |
+| `agent_mode_preview` | AgentModePreviewCard | Live preview of candidate mode |
+| `tool_call` | ToolCallCard | Tool call with arguments |
+| `tool_result` | ToolResultCard | Tool result with output |
+| default | DefaultCard | Fallback: raw JSON dump |
+
+The sticky scroll behavior is managed by `useStickyScrollFollow` in `cmd/web-chat/web/src/webchat/hooks/useStickyScrollFollow.ts`. This hook tracks whether the user has scrolled up from the bottom and auto-scrolls to the bottom when new entities arrive during streaming.
+
+**What can go wrong here:**
+
+- An entity has a kind that no renderer is registered for. The `DefaultCard` renders raw JSON, which is correct but ugly.
+- An entity has the right kind but missing or malformed props (e.g., no `content` field on a message). The renderer shows an empty bubble.
+- The sticky scroll hook does not detect the bottom correctly (browser rounding, CSS transforms, or dynamic heights).
+- React re-renders the entire timeline on every entity upsert because the `entities` array reference changes. This can cause flickering or performance issues in long conversations.
+- A deleted entity (`agent_mode_preview` after `ChatAgentModePreviewCleared`) leaves a brief flash before React removes it from the DOM.
+
+**What the debug tool should capture:**
+
+- The list of rendered entity IDs and their kinds after each update.
+- The scroll position and sticky mode after each entity update.
+- Any entities that fell through to the default renderer.
+
+## What Can Go Wrong: A Failure Mode Catalog
+
+This section lists the specific failure modes that have been observed or are plausible, organized by where they manifest.
+
+### Missing entities after reload
+
+**Symptom**: After page reload, one or more entities that were visible during live streaming are gone.
+
+**Possible causes**:
+1. The timeline projection did not create a timeline entity for the event. The live stream used the UI event directly, but the hydration path requires a timeline entity.
+2. The timeline entity was created with the wrong entity ID, overwriting a different entity.
+3. The hydration store failed to persist the entity (SQLite error, disk full).
+4. The snapshot frame was sent before the projection cursor advanced past the event.
+
+**How to diagnose**: Compare the backend events for the session (Layer 2) with the timeline entities in the hydration store (Layer 3). The entity should exist in the store for every backend event that `ProjectTimeline` handles.
+
+### Wrong entity ordering
+
+**Symptom**: Tool results appear before tool calls, or thinking blocks appear after the assistant response.
+
+**Possible causes**:
+1. The `upsertEntity` reducer overwrote `createdAt` with a later timestamp, moving the entity to the wrong position in the `order` array. (Fixed by preserving `createdAt` on upsert.)
+2. A live UI event used a different entity ID than the hydration snapshot, creating a duplicate instead of updating the original.
+3. The backend emitted events out of order (e.g., tool result before tool call finished).
+
+**How to diagnose**: Record the entity IDs and `createdAt` values before and after each upsert during live streaming. Compare with the snapshot entities after reload.
+
+### Duplicate entities
+
+**Symptom**: The same message or thinking block appears twice in the timeline.
+
+**Possible causes**:
+1. The hydration snapshot contains the entity, and then a buffered UI event re-creates it with a different ID.
+2. A `rekeyEntity` action failed to remove the old ID from the `order` array.
+3. The backend projected two timeline entities for the same logical item with different IDs.
+
+**How to diagnose**: Check the `byId` map for entities with identical `kind` and overlapping `props` but different IDs.
+
+### Stuck in streaming state
+
+**Symptom**: The app status shows "streaming" and never transitions to "finished" or "stopped".
+
+**Possible causes**:
+1. The `ChatMessageFinished` or `ChatMessageStopped` event was lost (WebSocket disconnect, frame dropped).
+2. The event arrived but the mutation returned `null` because `messageId` was missing.
+3. The event arrived but the status mutation was not applied because the Redux dispatch failed silently.
+
+**How to diagnose**: Record every UI event that sets `status: "streaming"`. Verify that a corresponding `status: "finished"` or `status: "stopped"` event exists with the same or later ordinal.
+
+### Hydration mismatch with live state
+
+**Symptom**: After reload, the conversation looks different than it did before reload. Missing entities, different ordering, or extra entities.
+
+**Possible causes**:
+1. The snapshot was taken at an earlier ordinal than the last UI event the frontend processed. Events between the snapshot ordinal and the last UI event are lost.
+2. The snapshot and the live stream use different entity IDs for the same logical entity.
+3. The `timelineEntityFromSnapshotEntity` function drops entities that `timelineMutationFromUIEvent` creates, or vice versa.
+
+**How to diagnose**: Record the snapshot ordinal and the last UI event ordinal before disconnect. After reconnect, compare the snapshot entity list with the pre-disconnect entity list.
+
+### Second tab divergence
+
+**Symptom**: Two tabs connected to the same session show different content.
+
+**Possible causes**:
+1. The second tab connected after the first tab had already processed several UI events. The second tab's snapshot is from an earlier ordinal.
+2. One tab reconnected and received a fresh snapshot while the other continued from live events.
+3. The `WsManager` is a singleton. The second tab's connect call disconnects the first tab's WebSocket.
+
+**How to diagnose**: Record WebSocket lifecycle events per tab. Check if a `disconnect` was issued for the first tab when the second tab connected.
+
+## Backend Event Recording Design
+
+The backend already persists backend events in the `sessionstream_events` SQLite table. This table has columns: `(session_id, ordinal, name, payload_json, created_at)`. It is the authoritative record of what the backend emitted.
+
+The existing table is sufficient for most investigation. What is missing is:
+
+1. **A convenient API to query it.** The current `GET /api/debug/sessions/{id}/events` endpoint (if it exists) or a new one should return events filtered by session, with optional filtering by event name and ordinal range.
+
+2. **Projection traceability.** For each backend event, we should be able to see which UI events and timeline entities it produced. This requires recording the projection output alongside the backend event.
+
+### Proposed schema additions
+
+```sql
+-- Existing table (already exists in sessionstream)
+CREATE TABLE sessionstream_events (
+    session_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY(session_id, ordinal)
+);
+
+-- New: projection trace table
+CREATE TABLE debug_projection_trace (
+    session_id TEXT NOT NULL,
+    backend_ordinal INTEGER NOT NULL,
+    projection_type TEXT NOT NULL,  -- "ui" or "timeline"
+    output_index INTEGER NOT NULL,  -- 0, 1, 2... for multiple outputs
+    output_name TEXT NOT NULL,      -- UI event name or timeline entity kind
+    output_id TEXT,                 -- timeline entity ID (null for UI events)
+    output_payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY(session_id, backend_ordinal, projection_type, output_index)
+);
+```
+
+### Proposed API
+
+```text
+GET /api/debug/sessions/{id}/events?after=0&limit=1000&name=ChatMessage
+GET /api/debug/sessions/{id}/projections?after=0&limit=1000
+GET /api/debug/sessions/{id}/trace?after=0&limit=100
+```
+
+The `trace` endpoint joins backend events with projection outputs, producing a single response that shows the full transformation chain for each ordinal.
+
+### Implementation approach
+
+The projection trace recording should be a thin wrapper around the existing `Engine.uiProjection()` and `Engine.timelineProjection()` methods. It should be opt-in (only when `--debug-api` is enabled) and should not affect the hot path when disabled.
+
+```go
+// Pseudocode for trace recording
+func (e *Engine) uiProjectionWithTrace(ctx context.Context, ev sessionstream.Event, ...) ([]sessionstream.UIEvent, error) {
+    projected, err := e.uiProjection(ctx, ev, sess, view)
+    if err != nil { return nil, err }
+    if e.debugRecorder != nil {
+        for i, ui := range projected {
+            e.debugRecorder.RecordProjection(ctx, ev.SessionId, ev.Ordinal, "ui", i, ui.Name, "", ui.Payload)
+        }
+    }
+    return projected, nil
+}
+```
+
+## Frontend Debug Mode Design
+
+The frontend debug mode captures everything that happens inside the browser: raw WebSocket frames, parsed frames, hydration snapshots, UI event mutations, and Redux state changes. It is activated by setting a flag in localStorage:
+
+```javascript
+localStorage.setItem('pinocchio.debugStream', '1')
+```
+
+When active, the `WsManager` records every frame it processes into an in-memory ring buffer. The buffer has a configurable maximum size (default: 10,000 entries). When the buffer fills, it drops the oldest entries.
+
+### Log entry types
+
+```typescript
+type DebugLogEntry =
+  | { type: 'raw-ws'; timestamp: number; data: string }
+  | { type: 'parsed-frame'; timestamp: number; frame: CanonicalFrame }
+  | { type: 'snapshot'; timestamp: number; entityCount: number; snapshotOrdinal: number; entities: Array<{kind: string; id: string; dropped: boolean}> }
+  | { type: 'ui-event'; timestamp: number; ordinal: number; name: string; messageId: string; mutation: TimelineMutation | null }
+  | { type: 'redux-action'; timestamp: number; actionType: string; entityId?: string; entityKind?: string }
+  | { type: 'ws-lifecycle'; timestamp: number; event: 'open' | 'close' | 'error' | 'subscribe' }
+  | { type: 'status'; timestamp: number; from: string; to: string };
+```
+
+### Debug panel
+
+A collapsible overlay panel renders the debug log. It supports:
+
+- **Filtering by type**: show only raw frames, parsed frames, mutations, or lifecycle events.
+- **Filtering by entity ID**: show only events related to a specific entity.
+- **Search**: full-text search across all log entries.
+- **Export**: download the entire log as a JSON file for offline analysis.
+
+The panel is rendered as a fixed-position overlay at the bottom of the screen, toggled by a keyboard shortcut (e.g., Ctrl+Shift+D) or a small button in the status bar.
+
+### Implementation approach
+
+The debug recorder is a class that wraps the existing `WsManager`. It intercepts calls to `handleFrame`, `applySnapshot`, and `applyUIEvent` and records the inputs and outputs.
+
+```typescript
+// Pseudocode for the debug recorder
+class StreamDebugRecorder {
+  private log: DebugLogEntry[] = [];
+  private maxEntries: number = 10_000;
+
+  record(entry: DebugLogEntry) {
+    if (!localStorage.getItem('pinocchio.debugStream')) return;
+    this.log.push(entry);
+    if (this.log.length > this.maxEntries) {
+      this.log.shift();
+    }
+  }
+
+  export(): DebugLogEntry[] { return [...this.log]; }
+  clear() { this.log = []; }
+}
+
+const debugRecorder = new StreamDebugRecorder();
+```
+
+The recorder is called from inside `WsManager.handleFrame()` and the projection functions. It is a no-op when the localStorage flag is not set.
+
+### Hydration detail recording
+
+When a snapshot arrives, the debug recorder should capture:
+
+- The raw snapshot ordinal.
+- The number of entities in the snapshot.
+- For each entity: kind, ID, whether `timelineEntityFromSnapshotEntity` mapped it successfully or returned `null`.
+- The number of buffered UI events that were replayed after the snapshot.
+- The time from snapshot receipt to all entities being upserted.
+
+This hydration detail is the most important debug output for investigating "missing after reload" bugs.
+
+## Reconciliation and Comparison Tools
+
+The reconciliation tool loads backend events and frontend debug logs for the same session and compares them. It runs as a script (or a debug API endpoint) and produces a report highlighting discrepancies.
+
+### Comparison algorithm
+
+```python
+# Pseudocode for reconciliation
+def reconcile(backend_events, frontend_log):
+    # 1. Build ordinal-indexed maps
+    backend_by_ordinal = {e.ordinal: e for e in backend_events}
+    frontend_received = {e.ordinal for e in frontend_log if e.type == 'ui-event'}
+
+    # 2. Find missing events (emitted but not received)
+    missing = set(backend_by_ordinal.keys()) - frontend_received
+
+    # 3. Find extra events (received but not emitted)
+    extra = frontend_received - set(backend_by_ordinal.keys())
+
+    # 4. Compare payloads for matching ordinals
+    mismatches = []
+    for ordinal in frontend_received & set(backend_by_ordinal.keys()):
+        be = backend_by_ordinal[ordinal]
+        fe = next(e for e in frontend_log if e.type == 'ui-event' and e.ordinal == ordinal)
+        if be.name != fe.name:
+            mismatches.append(('name', ordinal, be.name, fe.name))
+        if be.payload['messageId'] != fe.payload.get('messageId'):
+            mismatches.append(('messageId', ordinal, be.payload['messageId'], fe.payload.get('messageId')))
+
+    return {
+        'total_backend': len(backend_by_ordinal),
+        'total_frontend': len(frontend_received),
+        'missing': sorted(missing),
+        'extra': sorted(extra),
+        'mismatches': mismatches,
+    }
+```
+
+### Output format
+
+The reconciliation report is a JSON object:
+
+```json
+{
+  "session_id": "...",
+  "backend_event_count": 215,
+  "frontend_event_count": 213,
+  "missing_ordinals": [199, 200],
+  "extra_ordinals": [],
+  "payload_mismatches": [],
+  "hydration_snapshot_ordinal": 215,
+  "hydration_entity_count": 12,
+  "final_redux_entity_count": 11,
+  "entities_missing_from_redux": [
+    {"kind": "AgentMode", "id": "chat-msg-7"}
+  ]
+}
+```
+
+### Comparison between hydration and live state
+
+After a reload, the reconciliation tool should compare:
+
+1. The entities in the snapshot frame (what the server sent).
+2. The entities in the Redux store after hydration (what the frontend stored).
+3. The entities in the Redux store before reload (what the frontend had during live streaming).
+
+Any differences between these three sets indicate a hydration bug.
+
+### Implementation approach
+
+The reconciliation tool can be:
+
+1. **A Go script** that reads the backend events from the SQLite database and the frontend debug log from an exported JSON file.
+2. **A debug API endpoint** (`GET /api/debug/sessions/{id}/reconcile`) that reads both sources server-side.
+3. **A browser-side tool** that runs inside the debug panel and compares the in-memory log with a fetched backend event list.
+
+The first approach is the most practical for initial implementation because it does not require changes to the running server.
+
+## Test Scenarios
+
+Each scenario describes a specific user interaction pattern, what should happen, and what to look for in the debug logs.
+
+### Scenario 1: Normal chat flow
+
+1. Open Pinocchio web-chat.
+2. Type a prompt and press Enter.
+3. Wait for the response to complete (status changes to `finished`).
+
+**What to verify:**
+
+- The backend emitted `ChatInferenceStarted`, `ChatMessageAccepted`, `ChatMessageStarted`, one or more `ChatMessageAppended`, and `ChatMessageFinished`.
+- The frontend received all of these as UI events.
+- The Redux store has a user message entity and an assistant message entity.
+- No entities were dropped during parsing.
+
+### Scenario 2: Reload while streaming
+
+1. Open Pinocchio web-chat.
+2. Type a prompt and press Enter.
+3. While the response is still streaming (status is `streaming`), press F5 to reload the page.
+
+**What to verify:**
+
+- The backend continues running inference (it does not know the browser reloaded).
+- On reload, the frontend reconnects the WebSocket.
+- The server sends a snapshot containing all timeline entities that existed at the time of reconnection.
+- If inference completed while the browser was reloading, the snapshot includes the finished assistant message.
+- The frontend applies the snapshot and then replays any buffered UI events.
+- The final rendered state matches what a user who never reloaded would see.
+
+**What can go wrong:**
+
+- The snapshot is from an earlier ordinal than the last event the frontend processed before reload. Events between the snapshot and the disconnect are lost.
+- The frontend does not clear the Redux store before applying the snapshot, causing duplicate entities from the optimistic local state plus the snapshot entities.
+
+### Scenario 3: Open a second tab on the same conversation
+
+1. Open Pinocchio web-chat in Tab A.
+2. Send a prompt and wait for the response.
+3. Open the same URL (with `sessionId` query parameter) in Tab B.
+
+**What to verify:**
+
+- Tab B receives a snapshot with all entities from Tab A's conversation.
+- Tab B shows the same conversation as Tab A.
+
+**What can go wrong:**
+
+- The `WsManager` is a singleton. When Tab B calls `connect()`, it disconnects Tab A's WebSocket. Tab A stops receiving events.
+- The backend sends different snapshots to each tab if they subscribe at different times and projections have advanced.
+
+### Scenario 4: Reload second tab
+
+1. Open Tab A and Tab B as in Scenario 3.
+2. Send a new prompt in Tab A.
+3. While the response is streaming in Tab A, reload Tab B.
+
+**What to verify:**
+
+- Tab B reconnects and receives a snapshot that includes the entities from Tab A's original conversation plus any new entities from the streaming response.
+- Tab A continues streaming without interruption.
+
+**What can go wrong:**
+
+- Tab B's reconnect causes the `WsManager` singleton to disconnect Tab A. This is the same singleton issue as Scenario 3.
+- The snapshot sent to Tab B is stale (from before the new prompt) because the projection cursor has not advanced past the new events yet.
+
+### Scenario 5: Rapid sequential prompts
+
+1. Open Pinocchio web-chat.
+2. Send prompt A.
+3. Immediately send prompt B without waiting for prompt A to complete.
+
+**What to verify:**
+
+- The backend queues or cancels prompt A and processes prompt B.
+- The frontend does not mix entities from prompt A and prompt B.
+- Each message ID is unique and correctly mapped to its prompt.
+
+**What can go wrong:**
+
+- The backend publishes a `ChatMessageStopped` for prompt A and a `ChatInferenceStarted` for prompt B. If the frontend processes these out of order (due to buffering or WebSocket frame ordering), the status display may flicker.
+- Two inference loops run concurrently and publish events for different message IDs. The frontend must handle interleaved events correctly.
+
+### Scenario 6: Network interruption
+
+1. Open Pinocchio web-chat.
+2. Send a prompt.
+3. While streaming, disable the network (e.g., turn off Wi-Fi or use browser DevTools to go offline).
+4. Wait 10 seconds.
+5. Re-enable the network.
+
+**What to verify:**
+
+- The WebSocket detects the disconnect and fires `onclose`.
+- The frontend shows a disconnected status.
+- When the network returns, the frontend reconnects (if auto-reconnect is implemented) or the user manually reloads.
+- After reconnect, the frontend receives a snapshot that is consistent with the backend's current state.
+
+**What can go wrong:**
+
+- The WebSocket does not detect the disconnect for a long time (TCP keepalive timeout). The frontend appears connected but receives no events.
+- The backend continues processing and publishes events that no client receives. These events are persisted in the event log and timeline, so a future reconnect will see them.
+
+## File Reference
+
+### Backend (Go)
+
+| File | Purpose |
+|------|---------|
+| `pkg/chatapp/chat.go` | Engine: submits prompts, runs inference, publishes backend events. |
+| `pkg/chatapp/features.go` | `ChatPlugin` interface, plugin orchestration, projection routing. |
+| `pkg/chatapp/plugins/reasoning.go` | Reasoning plugin: handles Geppetto reasoning events, projects to UI events and timeline entities. |
+| `pkg/chatapp/plugins/toolcall.go` | Tool call plugin: handles tool call/result events, projects to UI events and timeline entities. |
+| `cmd/web-chat/agentmode_chat_feature.go` | AgentMode plugin: handles mode switch preview/committed events. |
+| `cmd/web-chat/app/server.go` | HTTP handler routing, WebSocket upgrade, session management. |
+| `cmd/web-chat/app/server_export.go` | Export endpoints (timeline, turns, minitrace). |
+| `cmd/web-chat/main.go` | CLI entry point, flag parsing, server setup. |
+
+### Sessionstream (Go, separate module)
+
+| File | Purpose |
+|------|---------|
+| `sessionstream/pkg/sessionstream/projection.go` | `UIProjection`, `TimelineProjection`, `UIEvent`, `TimelineEntity` types. |
+| `sessionstream/pkg/sessionstream/types.go` | `Event`, `Session`, `Snapshot`, `SessionId` types. |
+| `sessionstream/pkg/sessionstream/hydration.go` | `HydrationStore`, `EventStore`, `Snapshot` interfaces. |
+| `sessionstream/pkg/sessionstream/schema.go` | `SchemaRegistry` for event/entity name → protobuf type mapping. |
+
+### Frontend (TypeScript)
+
+| File | Purpose |
+|------|---------|
+| `cmd/web-chat/web/src/ws/protocol.ts` | WebSocket frame parsing, normalization, protobuf Any unwrapping. |
+| `cmd/web-chat/web/src/ws/wsManager.ts` | WebSocket lifecycle management, hydration, UI event dispatch, snapshot application. |
+| `cmd/web-chat/web/src/store/timelineSlice.ts` | Redux slice for timeline entities: upsert, delete, rekey, clear. |
+| `cmd/web-chat/web/src/store/appSlice.ts` | Redux slice for app state: convId, profile, status, wsStatus, lastSeq. |
+| `cmd/web-chat/web/src/webchat/ChatWidget.tsx` | Main chat widget: connects WebSocket, sends prompts, manages state. |
+| `cmd/web-chat/web/src/webchat/components/Timeline.tsx` | Timeline renderer: maps entities to renderers. |
+| `cmd/web-chat/web/src/webchat/cards.tsx` | Card renderers for each entity kind. |
+| `cmd/web-chat/web/src/webchat/hooks/useStickyScrollFollow.ts` | Sticky bottom-scroll hook. |
+| `cmd/web-chat/web/src/webchat/rendererRegistry.ts` | Resolves entity kind → React component. |
+| `cmd/web-chat/web/src/webchat/types.ts` | TypeScript types for entities, props, widget components. |
+
+### Geppetto (Go, separate module)
+
+| File | Purpose |
+|------|---------|
+| `geppetto/pkg/events/events.go` | Event types: `EventFinalEvent`, `EventAgentModeSwitch`, etc. |
+| `geppetto/pkg/inference/session/session.go` | Session management, history loading. |
+| `geppetto/pkg/turns/` | Turn accumulator model, block types, serialization. |
+
+## API Reference
+
+### HTTP Endpoints (Pinocchio web-chat)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/chat/sessions` | Create a new chat session. Returns `{ sessionId }`. |
+| `POST` | `/api/chat/sessions/{id}/messages` | Submit a prompt. Body: `{ prompt, profile }`. Returns `{ status }`. |
+| `GET` | `/api/chat/sessions/{id}` | Get current session snapshot (JSON). |
+| `POST` | `/api/chat/sessions/{id}/stop` | Stop running inference. |
+| `GET` | `/api/chat/ws` | WebSocket upgrade. Client sends `subscribe` frame after `hello`. |
+| `GET` | `/api/chat/sessions/{id}/timeline` | Export timeline entities. Query: `?format=json\|yaml&download=true`. |
+| `GET` | `/api/chat/sessions/{id}/turns` | Export turns. Query: `?format=json\|yaml\|minitrace&download=true`. |
+| `GET` | `/api/chat/sessions/{id}/export` | Full export (timeline + turns). Query: `?format=json\|yaml&download=true`. |
+
+### WebSocket Frame Types (Server → Client)
+
+| Frame Type | Direction | Fields |
+|-----------|-----------|--------|
+| `hello` | Server → Client | `{ type: "hello" }` |
+| `snapshot` | Server → Client | `{ type: "snapshot", sessionId, ordinal, entities[] }` |
+| `subscribed` | Server → Client | `{ type: "subscribed", sessionId, ordinal }` |
+| `uiEvent` | Server → Client | `{ type: "ui-event", sessionId, ordinal, name, payload }` |
+| `error` | Server → Client | `{ type: "error", message, code, detail }` |
+| `ping` | Server → Client | `{ type: "ping" }` |
+
+### WebSocket Frame Types (Client → Server)
+
+| Frame Type | Direction | Fields |
+|-----------|-----------|--------|
+| `subscribe` | Client → Server | `{ subscribe: { sessionId, sinceSnapshotOrdinal } }` |
+
+### UI Event Names
+
+| Event Name | Payload Type | Produces |
+|-----------|-------------|----------|
+| `ChatMessageAccepted` | `ChatMessageUpdate` | Upsert user message |
+| `ChatMessageStarted` | `ChatMessageUpdate` | Upsert assistant message (streaming start) |
+| `ChatMessageAppended` | `ChatMessageUpdate` | Upsert assistant message (text chunk) |
+| `ChatMessageFinished` | `ChatMessageUpdate` | Upsert assistant message (complete) |
+| `ChatMessageStopped` | `ChatMessageUpdate` | Upsert assistant message (stopped/error) |
+| `ChatReasoningStarted` | `ReasoningUpdate` | Upsert thinking entity (start) |
+| `ChatReasoningAppended` | `ReasoningUpdate` | Upsert thinking entity (delta) |
+| `ChatReasoningFinished` | `ReasoningUpdate` | Upsert thinking entity (complete) |
+| `ChatAgentModePreviewUpdated` | `AgentModePreviewUpdate` | Upsert mode preview |
+| `ChatAgentModeCommitted` | `AgentModeCommittedUpdate` | Upsert committed mode + clear preview |
+| `ChatAgentModePreviewCleared` | `AgentModePreviewCleared` | Delete mode preview |
+| `ChatToolCallStarted` | `ToolCallUpdate` | Upsert tool call entity |
+| `ChatToolCallUpdated` | `ToolCallUpdate` | Upsert tool call entity |
+| `ChatToolCallFinished` | `ToolCallUpdate` | Upsert tool call entity |
+| `ChatToolResultReady` | `ToolResultUpdate` | Upsert tool result entity |
+
+### Timeline Entity Kinds
+
+| Kind | Protobuf Type | ID Source |
+|------|--------------|-----------|
+| `ChatMessage` | `ChatMessageEntity` | `payload.messageId` |
+| `AgentMode` | `AgentModeEntity` | Message ID of the committed event |
+| `tool_call` | `ToolCallEntity` | Tool call ID from the model |
+| `tool_result` | `ToolResultEntity` | Tool result ID |
+
+### Redux Actions (timelineSlice)
+
+| Action | Effect |
+|--------|--------|
+| `upsertEntity` | Insert new entity or merge props into existing entity. Preserves `createdAt`. |
+| `deleteEntity` | Remove entity by ID. |
+| `rekeyEntity` | Change entity ID (used for optimistic → final ID mapping). |
+| `clear` | Remove all entities. Called before snapshot application. |
+
+### Debug Flags (localStorage)
+
+| Flag | Purpose |
+|------|---------|
+| `pinocchio.debugStream` | Enable frontend debug recording. |
+| `pinocchio.debugScroll` | Enable sticky scroll debug logging (prefix: `[pinocchio-scroll]`). |

--- a/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/index.md
+++ b/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/index.md
@@ -1,0 +1,70 @@
+---
+Title: "Investigate and Harden Web-Chat Streaming Robustness with Event Recording and Frontend Debug Mode"
+Ticket: PINO-STREAM-DEBUG
+Status: active
+Topics:
+    - streaming-robustness
+    - event-recording
+    - frontend-debug
+    - hydration
+    - websocket
+    - sessionstream
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/web-chat/web/src/ws/wsManager.ts
+      Note: Frontend WebSocket manager — receives, parses, buffers, and dispatches frames
+    - Path: cmd/web-chat/web/src/ws/protocol.ts
+      Note: Protobuf JSON frame parser and normalizer
+    - Path: cmd/web-chat/web/src/store/timelineSlice.ts
+      Note: Redux slice for timeline entity upsert/delete/rekey operations
+    - Path: cmd/web-chat/web/src/webchat/components/Timeline.tsx
+      Note: React timeline renderer — maps entities to renderers
+    - Path: cmd/web-chat/web/src/webchat/cards.tsx
+      Note: Card renderers for chat messages, thinking blocks, agent mode
+    - Path: cmd/web-chat/web/src/webchat/hooks/useStickyScrollFollow.ts
+      Note: Sticky bottom-scroll hook for streaming UX
+    - Path: pkg/chatapp/chat.go
+      Note: Chatapp engine — publishes backend events, runs inference loop
+    - Path: pkg/chatapp/features.go
+      Note: ChatPlugin interface — ProjectUI, ProjectTimeline, HandleRuntimeEvent
+    - Path: pkg/chatapp/plugins/reasoning.go
+      Note: Reasoning plugin — backend event to UI/timeline projection
+    - Path: pkg/chatapp/plugins/toolcall.go
+      Note: Tool call plugin — backend event to UI/timeline projection
+    - Path: cmd/web-chat/agentmode_chat_feature.go
+      Note: AgentMode plugin — preview/committed mode switches
+ExternalSources: []
+Summary: "Build investigation and debugging tools for the Pinocchio web-chat streaming pipeline: record all backend events, record all frontend WebSocket frames and hydration snapshots, and provide a debug UI for comparing backend-emitted vs frontend-received event sequences to find discrepancies in parsing, projection, and rendering."
+LastUpdated: 2026-05-07T00:30:00-04:00
+WhatFor: "When streaming chat responses go wrong — missing entities, wrong order, lost events on reload, hydration mismatches — there is no structured way to compare what the backend emitted versus what the frontend received and rendered. This ticket creates that investigation layer."
+WhenToUse: "Use when debugging streaming discrepancies, hydration bugs, event ordering issues, or rendering gaps in the Pinocchio web-chat."
+---
+
+
+
+# Investigate and Harden Web-Chat Streaming Robustness with Event Recording and Frontend Debug Mode
+
+## Overview
+
+This ticket creates a structured investigation and debugging layer for the Pinocchio web-chat streaming pipeline. The goal is to make it possible to compare, at every stage, what the backend emitted, what the WebSocket transported, what the frontend parsed, what the projections produced, and what the Redux store rendered.
+
+## Status
+
+Current status: **active**
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Investigation diary, API contracts, context summaries
+- playbooks/ - Debug procedures and test scenarios
+- scripts/ - Investigation scripts and tools

--- a/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/tasks.md
+++ b/ttmp/2026/05/07/PINO-STREAM-DEBUG--investigate-and-harden-web-chat-streaming-robustness-with-event-recording-and-frontend-debug-mode/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## Phase 0: Design and planning
+
+- [x] Create ticket PINO-STREAM-DEBUG.
+- [ ] Analyze the full streaming pipeline: backend event emission → WebSocket transport → frontend parsing → projection → Redux state → rendering.
+- [ ] Design the event recording format for backend events (what to persist, where, and how to query).
+- [ ] Design the frontend debug mode: what to capture, how to store, how to present.
+- [ ] Design the comparison/reconciliation tool for backend-emitted vs frontend-received event sequences.
+
+## Phase 1: Backend event recording
+
+- [ ] Add a debug event recorder that captures all backend events for a session in a structured log (SQLite table or JSONL file).
+- [ ] Record event ordinal, event name, payload type, payload JSON, and timestamp.
+- [ ] Add a debug API endpoint to retrieve recorded events for a session (e.g., `GET /api/debug/sessions/{id}/events`).
+- [ ] Make event recording opt-in via `--debug-api` flag or environment variable.
+
+## Phase 2: Frontend debug mode
+
+- [ ] Add a `debugStream` flag activated by `localStorage.setItem('pinocchio.debugStream', '1')`.
+- [ ] When active, record every raw WebSocket message, every parsed frame, every hydration entity, every UI event, and every timeline mutation to an in-memory log.
+- [ ] Add a debug panel (collapsible overlay) that shows the recorded log with filtering by type (raw, parsed, snapshot, ui-event, mutation).
+- [ ] Show hydration snapshot details: entity count per kind, snapshot ordinal, hydration timestamp.
+- [ ] Allow exporting the debug log as JSON for offline comparison.
+
+## Phase 3: Comparison and reconciliation tools
+
+- [ ] Build a reconciliation script/endpoint that loads backend events and frontend log for the same session and highlights discrepancies.
+- [ ] Detect: missing events (emitted but not received), extra events (received but not emitted), ordering differences, payload mismatches.
+- [ ] Build a diff view for hydration snapshot vs live-rendered state after streaming completes.
+
+## Phase 4: Robustness testing scenarios
+
+- [ ] Scenario: normal chat flow — send prompt, receive streaming response, verify all entities rendered.
+- [ ] Scenario: reload while streaming — mid-stream page reload, reconnect, re-hydrate, verify state matches.
+- [ ] Scenario: second tab on same conversation — open second browser tab, subscribe to same session, verify both tabs receive events.
+- [ ] Scenario: reload second tab — reload one tab while other continues streaming, verify recovery.
+- [ ] Scenario: rapid sequential prompts — send multiple prompts without waiting for completion, verify no event cross-contamination.
+- [ ] Scenario: network interruption — simulate WebSocket disconnect/reconnect, verify re-hydration.
+
+## Phase 5: Hardening
+
+- [ ] Fix any discrepancies found during Phase 4 testing.
+- [ ] Add regression tests for discovered edge cases.
+- [ ] Document the debug mode usage in a playbook.


### PR DESCRIPTION
This change introduces a feature to export conversation data from the web chat
interface. This is primarily intended for debugging and analysis.

### Backend
- A new `chatapp/export` package encapsulates the export logic.
- New API endpoints are added to the session router:
  - `.../sessions/{sid}/timeline`: Exports the raw sessionstream timeline events.
  - `.../sessions/{sid}/turns`: Exports the structured conversation turns.
  - `.../sessions/{sid}/export`: Exports a full bundle containing both timeline
    and turns data.
- Supported export formats include JSON and YAML.
- A Minitrace format is also supported for `turns` export, which requires a
  direct path to the underlying SQLite turns database. This is configured via a
  new `WithTurnsDBPath` server option.

### Frontend
- A new `ExportMenu` React component is added to the web chat status bar.
- The menu provides download links for different data views (Full, Timeline,
  Turns) and formats (JSON, YAML, Minitrace).

### Other Changes
- The timeline entity ID for agent mode is now based on the message ID to
  ensure uniqueness and stability.