### PR TITLE
Add optional model metadata to engine profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ profiles:
       chat:
         api_type: openai
         engine: gpt-4o-mini
+      model_info:
+        id: gpt-4o-mini
+        name: GPT-4o Mini
+        reasoning: false
+        input:
+          - text
+          - image
+        context_window: 128000
+        quality_high_watermark: 128000
+        max_output_tokens: 16384
+        cost:
+          input: 0.15
+          output: 0.60
+          cache_read: 0.075
+          cache_write: 0.30
   gpt-5-mini:
     slug: gpt-5-mini
     stack:
@@ -155,7 +170,12 @@ profiles:
     inference_settings:
       chat:
         engine: gpt-5-mini
+      model_info:
+        id: gpt-5-mini
+        reasoning: true
 ```
+
+`model_info` is optional static model metadata. Pinocchio surfaces it in profile APIs and profile-switch UI so consumers can display reasoning support, input modalities, context limits, and cost information. `context_window` is the hard limit; `quality_high_watermark` is the planning limit where model quality is expected to remain high. Cost values are USD per one million tokens.
 
 Keep prompts, middlewares, and tool selection out of this file. Those are application-level concerns now.
 

--- a/cmd/web-chat/README.md
+++ b/cmd/web-chat/README.md
@@ -27,6 +27,7 @@ SectionType: GeneralTopic
   - `GET /api/chat/sessions/:sessionId`
   - `GET /api/chat/ws`
 - Profile selection APIs remain app-owned under `/api/chat/profile*`.
+- Profile list/detail responses include optional `model_info` from the selected engine profile so the frontend can render model capabilities, context limits, and cost metadata.
 - The embedded web UI is served directly from `cmd/web-chat/static`.
 - Base chat messages use protobuf payloads from `proto/pinocchio/chatapp/v1/chat.proto`.
 - Shared reasoning and tool-call projections are wired through `pkg/chatapp/plugins`.
@@ -62,7 +63,7 @@ Canonical live routes:
 - `POST /api/chat/sessions/:sessionId/messages`
 - `GET /api/chat/sessions/:sessionId`
 - `GET /api/chat/ws`
-- `GET /api/chat/profiles` (app-owned)
+- `GET /api/chat/profiles` (app-owned, includes optional `model_info` per profile)
 - `GET /api/chat/profile` (app-owned)
 - `POST /api/chat/profile` (app-owned)
 

--- a/cmd/web-chat/profiles/api.go
+++ b/cmd/web-chat/profiles/api.go
@@ -10,6 +10,7 @@ import (
 
 	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
 	"github.com/go-go-golems/geppetto/pkg/inference/middlewarecfg"
+	aisettings "github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	infruntime "github.com/go-go-golems/pinocchio/pkg/inference/runtime"
 )
 
@@ -312,6 +313,9 @@ func profileDocFromModel(registrySlug gepprofiles.RegistrySlug, registry *geppro
 	}
 	doc.Metadata = p.Metadata
 	doc.Extensions = cloneExtensionMap(p.Extensions)
+	if p.InferenceSettings != nil {
+		doc.ModelInfo = p.InferenceSettings.ModelInfo.Clone()
+	}
 	doc.IsDefault = registry != nil && registry.DefaultEngineProfileSlug == p.Slug
 	return doc
 }
@@ -336,6 +340,10 @@ func profileListItemsFromRegistry(registrySlug gepprofiles.RegistrySlug, registr
 		if runtime, _, err := infruntime.ProfileRuntimeFromEngineProfile(p); err == nil && runtime != nil {
 			defaultPrompt = runtime.SystemPrompt
 		}
+		var modelInfo *aisettings.ModelInfo
+		if p.InferenceSettings != nil {
+			modelInfo = p.InferenceSettings.ModelInfo.Clone()
+		}
 		items = append(items, ProfileListItem{
 			Registry:      registrySlug.String(),
 			Slug:          p.Slug.String(),
@@ -343,6 +351,7 @@ func profileListItemsFromRegistry(registrySlug gepprofiles.RegistrySlug, registr
 			Description:   p.Description,
 			DefaultPrompt: defaultPrompt,
 			Extensions:    cloneExtensionMap(p.Extensions),
+			ModelInfo:     modelInfo,
 			IsDefault:     registry != nil && registry.DefaultEngineProfileSlug == p.Slug,
 			Version:       p.Metadata.Version,
 		})

--- a/cmd/web-chat/profiles/types.go
+++ b/cmd/web-chat/profiles/types.go
@@ -51,14 +51,15 @@ type ResolvedRuntime struct {
 
 // ProfileListItem is the JSON shape for profile listing.
 type ProfileListItem struct {
-	Registry      string         `json:"registry"`
-	Slug          string         `json:"slug"`
-	DisplayName   string         `json:"display_name,omitempty"`
-	Description   string         `json:"description,omitempty"`
-	DefaultPrompt string         `json:"default_prompt,omitempty"`
-	Extensions    map[string]any `json:"extensions,omitempty"`
-	IsDefault     bool           `json:"is_default,omitempty"`
-	Version       uint64         `json:"version,omitempty"`
+	Registry      string                `json:"registry"`
+	Slug          string                `json:"slug"`
+	DisplayName   string                `json:"display_name,omitempty"`
+	Description   string                `json:"description,omitempty"`
+	DefaultPrompt string                `json:"default_prompt,omitempty"`
+	Extensions    map[string]any        `json:"extensions,omitempty"`
+	ModelInfo     *aisettings.ModelInfo `json:"model_info,omitempty"`
+	IsDefault     bool                  `json:"is_default,omitempty"`
+	Version       uint64                `json:"version,omitempty"`
 }
 
 // ProfileDocument is the JSON shape for a single profile detail response.
@@ -70,6 +71,7 @@ type ProfileDocument struct {
 	Runtime     *infruntime.ProfileRuntime        `json:"runtime,omitempty"`
 	Metadata    gepprofiles.EngineProfileMetadata `json:"metadata,omitempty"`
 	Extensions  map[string]any                    `json:"extensions,omitempty"`
+	ModelInfo   *aisettings.ModelInfo             `json:"model_info,omitempty"`
 	IsDefault   bool                              `json:"is_default"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/bobatea v0.1.5
 	github.com/go-go-golems/clay v0.4.9
-	github.com/go-go-golems/geppetto v0.11.26
+	github.com/go-go-golems/geppetto v0.11.27
 	github.com/go-go-golems/glazed v1.2.7
-	github.com/go-go-golems/go-go-goja v0.4.15
+	github.com/go-go-golems/go-go-goja v0.4.16
 	github.com/go-go-golems/sessionstream v0.0.5
 	github.com/go-go-golems/uhoh v0.0.5
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -195,12 +195,12 @@ github.com/go-go-golems/bobatea v0.1.5 h1:WjY9dxJcTy+iGOoE9ROriSt6+m7j1Fedp2lUGN
 github.com/go-go-golems/bobatea v0.1.5/go.mod h1:FB1zWnEyIUOBDwtTXN7qRSEA8C7lxZ5KbowTUoHaa0g=
 github.com/go-go-golems/clay v0.4.9 h1:AEYlOOCUnjhQtDkvOLsr7MT1NY1bISPEm0bUqgbEixo=
 github.com/go-go-golems/clay v0.4.9/go.mod h1:xvi5Ii4B4GkuKAHIfEWKbhQ6yVCNXmDRsmQHsyklJpw=
-github.com/go-go-golems/geppetto v0.11.26 h1:iYyPw5IwVwDCNBb1fhvVnxTrpleeYOWVBi7aIxdfZjs=
-github.com/go-go-golems/geppetto v0.11.26/go.mod h1:CF9CKLHG9oO+SeQlLvDRv1d/mE3arGUtlONX9j5D8oI=
+github.com/go-go-golems/geppetto v0.11.27 h1:wTZQcVDbnAJc53pXM5xjbYqkk7Q+Or8rmDeVh+aah2Y=
+github.com/go-go-golems/geppetto v0.11.27/go.mod h1:CF9CKLHG9oO+SeQlLvDRv1d/mE3arGUtlONX9j5D8oI=
 github.com/go-go-golems/glazed v1.2.7 h1:/zSSeteH++rsJDmTmIZappaGpEXKT40GvtZgBfGPBvw=
 github.com/go-go-golems/glazed v1.2.7/go.mod h1:1oF2sFLSCHFJBGx7xQ/pIXI+9WLZhonD4U8X46AqQrM=
-github.com/go-go-golems/go-go-goja v0.4.15 h1:0PNFBk4yRpfvi3o/cP5ciduyJGB3b52EINGTpBcgOYg=
-github.com/go-go-golems/go-go-goja v0.4.15/go.mod h1:mnEFH70HM3+JROMsBSBNTV8REF0K4YSYes6d0NS900o=
+github.com/go-go-golems/go-go-goja v0.4.16 h1:IveXWTtNZKhCbWyhvs9rsStGnlM+O1Cz1K0xMrnkB3k=
+github.com/go-go-golems/go-go-goja v0.4.16/go.mod h1:RbqZWjsZh4Q3Qv9SwQgbkKzRdSqGHzYxbr6naky2y3M=
 github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=
 github.com/go-go-golems/sanitize v0.0.1/go.mod h1:ahtFsvUHMZC+/CIRxbrC5RKEqgCcyDyd6fSns+zWEN0=
 github.com/go-go-golems/sessionstream v0.0.5 h1:AnzJPqAyzErw86GeBLuFnfadw+h+9J6Pb5g1WVPKx9M=

--- a/pkg/ui/profileswitch/manager.go
+++ b/pkg/ui/profileswitch/manager.go
@@ -105,6 +105,10 @@ func (m *Manager) ListEngineProfiles(ctx context.Context) ([]ProfileListItem, er
 			if p == nil {
 				continue
 			}
+			var modelInfo *settings.ModelInfo
+			if p.InferenceSettings != nil {
+				modelInfo = p.InferenceSettings.ModelInfo.Clone()
+			}
 			items = append(items, ProfileListItem{
 				RegistrySlug: regSlug,
 				ProfileSlug:  p.Slug,
@@ -112,6 +116,7 @@ func (m *Manager) ListEngineProfiles(ctx context.Context) ([]ProfileListItem, er
 				Description:  strings.TrimSpace(p.Description),
 				IsDefault:    rs.DefaultEngineProfileSlug == p.Slug,
 				Version:      p.Metadata.Version,
+				ModelInfo:    modelInfo,
 			})
 		}
 	}

--- a/pkg/ui/profileswitch/picker.go
+++ b/pkg/ui/profileswitch/picker.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	overlaywidget "github.com/go-go-golems/pinocchio/pkg/tui/widgets/overlay"
 )
 
@@ -155,6 +156,9 @@ func (m *PickerModel) View() string {
 		if name := strings.TrimSpace(it.DisplayName); name != "" && name != slug {
 			label += " — " + name
 		}
+		if modelSummary := profileModelInfoSummary(it.ModelInfo); modelSummary != "" {
+			label += " " + modelSummary
+		}
 
 		line := marker + label
 
@@ -219,6 +223,46 @@ func (m *PickerModel) SetSize(w, h int) {
 }
 
 // rebuildFiltered rebuilds the filtered index list from the current filter string.
+func profileModelInfoSummary(info *settings.ModelInfo) string {
+	if info == nil {
+		return ""
+	}
+	parts := []string{}
+	if info.Reasoning != nil && *info.Reasoning {
+		parts = append(parts, "✨")
+	}
+	if len(info.Input) > 0 {
+		modalities := make([]string, 0, len(info.Input))
+		for _, modality := range info.Input {
+			switch modality {
+			case settings.InputModalityImage:
+				modalities = append(modalities, "🖼")
+			case settings.InputModalityAudio:
+				modalities = append(modalities, "🎵")
+			case settings.InputModalityVideo:
+				modalities = append(modalities, "🎬")
+			case settings.InputModalityPDF:
+				modalities = append(modalities, "📄")
+			case settings.InputModalityText:
+				modalities = append(modalities, "📝")
+			default:
+				modalities = append(modalities, string(modality))
+			}
+		}
+		parts = append(parts, strings.Join(modalities, ""))
+	}
+	if limit := info.EffectiveContextLimit(); limit > 0 {
+		parts = append(parts, fmt.Sprintf("ctx:%dk", limit/1000))
+	}
+	if info.Cost != nil && (info.Cost.Input != 0 || info.Cost.Output != 0) {
+		parts = append(parts, fmt.Sprintf("$%.2f/%.2f", info.Cost.Input, info.Cost.Output))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
 func (m *PickerModel) rebuildFiltered() {
 	if m.filter == "" {
 		m.filtered = make([]int, len(m.items))

--- a/pkg/ui/profileswitch/types.go
+++ b/pkg/ui/profileswitch/types.go
@@ -12,6 +12,7 @@ type ProfileListItem struct {
 	Description  string
 	IsDefault    bool
 	Version      uint64
+	ModelInfo    *settings.ModelInfo
 }
 
 // Resolved captures the selected engine profile and the final merged


### PR DESCRIPTION
This change introduces an optional `model_info` section to engine profiles,
allowing static metadata about the underlying model to be defined and
surfaced to users.

Key changes:
-   Adds a new `model_info` configuration block within a profile's
    `inference_settings`.
-   This block can contain details such as reasoning support, input
    modalities (e.g., text, image), context limits, and cost information.
-   The `web-chat` profile APIs (`/api/chat/profiles`) now expose this
    metadata in their responses, making it available to frontends.
-   The TUI profile switcher is updated to display this information, giving
    users more context when selecting a model.