### PR TITLE
Refactor streaming events to a patch-based protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lintmax: build geppetto-lint-build golangci-lint-install
 
 gosec:
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
-	gosec -exclude=G101,G203,G304,G301,G306,G204,G302 -exclude-generated -exclude-dir=.history -exclude-dir=testdata -exclude-dir=pkg/sem/pb ./...
+	gosec -exclude=G101,G203,G304,G301,G306,G204,G302 -exclude-generated -exclude-dir=.history -exclude-dir=testdata -exclude-dir=pkg/sem/pb -exclude-dir=pkg/chatapp/pb ./...
 
 govulncheck:
 	go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/cmd/web-chat/app/debug_reconcile_views.go
+++ b/cmd/web-chat/app/debug_reconcile_views.go
@@ -139,7 +139,7 @@ func createDebugSQLiteViews(ctx context.Context, db *sql.DB) error {
 		     FROM backend_pipeline bp
 		     JOIN backend_records br ON br.id = bp.record_id
 		     JOIN backend_pipeline_ui_events bpue ON bpue.record_id = br.id
-		    WHERE bp.event_name = 'ChatReasoningDelta'
+		    WHERE bp.event_name = 'ChatReasoningPatch'
 		      AND bpue.source = 'uiEvents'
 		 ),
 		 frontend_reasoning AS (
@@ -153,10 +153,10 @@ func createDebugSQLiteViews(ctx context.Context, db *sql.DB) error {
 		          json_extract(fpf.frame_json, '$.payload.correlation.outputIndex') AS frontend_output_index,
 		          json_extract(fpf.frame_json, '$.payload.correlation.summaryIndex') AS frontend_summary_index,
 		          json_extract(fpf.frame_json, '$.payload.correlation.correlationKey') AS frontend_correlation_key,
-		          json_extract(fpf.frame_json, '$.payload.chunk') AS frontend_chunk
+		          json_extract(fpf.frame_json, '$.payload.text') AS frontend_chunk
 		     FROM frontend_parsed_frames fpf
 		     JOIN frontend_records fr ON fr.id = fpf.record_id
-		    WHERE fpf.name = 'ChatReasoningDelta'
+		    WHERE fpf.name = 'ChatReasoningPatch'
 		 ),
 		 frontend_mutation AS (
 		   SELECT fr.ordinal,
@@ -164,7 +164,7 @@ func createDebugSQLiteViews(ctx context.Context, db *sql.DB) error {
 		          fui.message_id AS ui_mutation_message_id
 		     FROM frontend_ui_events fui
 		     JOIN frontend_records fr ON fr.id = fui.record_id
-		    WHERE fui.name = 'ChatReasoningDelta'
+		    WHERE fui.name = 'ChatReasoningPatch'
 		 )
 		 SELECT pd.rn,
 		        pd.provider_record_id,
@@ -237,7 +237,7 @@ func createDebugSQLiteViews(ctx context.Context, db *sql.DB) error {
 		          json_extract(fpf.frame_json, '$.payload.messageId') AS frontend_message_id,
 		          json_extract(fpf.frame_json, '$.payload.correlation.correlationKey') AS frontend_correlation_key,
 		          json_extract(fpf.frame_json, '$.payload.correlation.streamKind') AS frontend_stream_kind,
-		          json_extract(fpf.frame_json, '$.payload.chunk') AS frontend_chunk,
+		          json_extract(fpf.frame_json, '$.payload.text') AS frontend_chunk,
 		          json_extract(fpf.frame_json, '$.payload.toolCallId') AS frontend_tool_call_id
 		     FROM frontend_parsed_frames fpf
 		     JOIN frontend_records fr ON fr.id = fpf.record_id

--- a/cmd/web-chat/reasoning_chat_feature_test.go
+++ b/cmd/web-chat/reasoning_chat_feature_test.go
@@ -43,8 +43,8 @@ func TestReasoningChatFeatureHandleRuntimeEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, handled)
 	require.Len(t, published, 1)
-	require.Equal(t, plugins.ReasoningDeltaEventName, published[0].Name)
-	require.Equal(t, "chat-msg-1:thinking:reasoning-1", published[0].Payload.(*chatappv1.ChatReasoningDelta).GetMessageId())
+	require.Equal(t, plugins.ReasoningPatchEventName, published[0].Name)
+	require.Equal(t, "chat-msg-1:thinking:reasoning-1", published[0].Payload.(*chatappv1.ChatReasoningPatch).GetMessageId())
 
 	handled, err = feature.HandleRuntimeEvent(context.Background(), ctx, gepevents.NewReasoningSegmentFinishedEvent(meta, corr, "short summary", "summary"))
 	require.NoError(t, err)
@@ -57,22 +57,22 @@ func TestReasoningChatFeatureHandleRuntimeEvent(t *testing.T) {
 func TestReasoningChatFeatureProjectsUIAndTimeline(t *testing.T) {
 	feature := plugins.NewReasoningPlugin()
 
-	deltaPayload := &chatappv1.ChatReasoningDelta{
+	deltaPayload := &chatappv1.ChatReasoningPatch{
 		MessageId:       "chat-msg-2:thinking:1",
 		ParentMessageId: "chat-msg-2",
-		Content:         "thinking out loud",
+		Text:            "thinking out loud",
+		Mode:            chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
 		Status:          "streaming",
-		Streaming:       true,
 		Correlation:     &chatappv1.CorrelationInfo{SegmentId: "reasoning-1"},
 	}
 
-	uiEvents, handled, err := feature.ProjectUI(context.Background(), sessionstream.Event{Name: plugins.ReasoningDeltaEventName, SessionId: "sid", Ordinal: 7, Payload: deltaPayload}, nil, reasoningStaticTimelineView{})
+	uiEvents, handled, err := feature.ProjectUI(context.Background(), sessionstream.Event{Name: plugins.ReasoningPatchEventName, SessionId: "sid", Ordinal: 7, Payload: deltaPayload}, nil, reasoningStaticTimelineView{})
 	require.NoError(t, err)
 	require.True(t, handled)
 	require.Len(t, uiEvents, 1)
-	require.Equal(t, plugins.ReasoningDeltaEventName, uiEvents[0].Name)
+	require.Equal(t, plugins.ReasoningPatchEventName, uiEvents[0].Name)
 
-	entities, handled, err := feature.ProjectTimeline(context.Background(), sessionstream.Event{Name: plugins.ReasoningDeltaEventName, SessionId: "sid", Ordinal: 7, Payload: deltaPayload}, nil, reasoningStaticTimelineView{})
+	entities, handled, err := feature.ProjectTimeline(context.Background(), sessionstream.Event{Name: plugins.ReasoningPatchEventName, SessionId: "sid", Ordinal: 7, Payload: deltaPayload}, nil, reasoningStaticTimelineView{})
 	require.NoError(t, err)
 	require.True(t, handled)
 	require.Len(t, entities, 1)

--- a/cmd/web-chat/web/src/chatapp/pb/proto/pinocchio/chatapp/v1/chat_pb.ts
+++ b/cmd/web-chat/web/src/chatapp/pb/proto/pinocchio/chatapp/v1/chat_pb.ts
@@ -3,14 +3,14 @@
 /* eslint-disable */
 
 import type { Message } from "@bufbuild/protobuf";
-import type { GenFile, GenMessage } from "@bufbuild/protobuf/codegenv2";
-import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv2";
+import type { GenEnum, GenFile, GenMessage } from "@bufbuild/protobuf/codegenv2";
+import { enumDesc, fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv2";
 
 /**
  * Describes the file proto/pinocchio/chatapp/v1/chat.proto.
  */
 export const file_proto_pinocchio_chatapp_v1_chat: GenFile = /*@__PURE__*/
-  fileDesc("CiVwcm90by9waW5vY2NoaW8vY2hhdGFwcC92MS9jaGF0LnByb3RvEhRwaW5vY2NoaW8uY2hhdGFwcC52MSJUChVTdGFydEluZmVyZW5jZUNvbW1hbmQSDgoGcHJvbXB0GAEgASgJEhcKD2lkZW1wb3RlbmN5X2tleRgCIAEoCRISCgpyZXF1ZXN0X2lkGAMgASgJIhYKFFN0b3BJbmZlcmVuY2VDb21tYW5kIpUBCglVc2FnZUluZm8SFAoMaW5wdXRfdG9rZW5zGAEgASgFEhUKDW91dHB1dF90b2tlbnMYAiABKAUSFQoNY2FjaGVkX3Rva2VucxgDIAEoBRIjChtjYWNoZV9jcmVhdGlvbl9pbnB1dF90b2tlbnMYBCABKAUSHwoXY2FjaGVfcmVhZF9pbnB1dF90b2tlbnMYBSABKAUiigEKD0NvcnJlbGF0aW9uSW5mbxISCgpzZXNzaW9uX2lkGAEgASgJEg4KBnJ1bl9pZBgCIAEoCRIPCgd0dXJuX2lkGAQgASgJEhgKEHByb3ZpZGVyX2NhbGxfaWQYBSABKAkSEgoKc2VnbWVudF9pZBgPIAEoCRIUCgx0b29sX2NhbGxfaWQYEyABKAkicAoOQ2hhdFJ1blN0YXJ0ZWQSEgoKbWVzc2FnZV9pZBgBIAEoCRIOCgZwcm9tcHQYAiABKAkSOgoLY29ycmVsYXRpb24YAyABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8iqgEKD0NoYXRSdW5GaW5pc2hlZBISCgptZXNzYWdlX2lkGAEgASgJEg4KBnN0YXR1cxgCIAEoCRINCgVlcnJvchgDIAEoCRIYCgtkdXJhdGlvbl9tcxgEIAEoA0gAiAEBEjoKC2NvcnJlbGF0aW9uGAUgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvQg4KDF9kdXJhdGlvbl9tcyJ/Cg5DaGF0UnVuU3RvcHBlZBISCgptZXNzYWdlX2lkGAEgASgJEg4KBnN0YXR1cxgCIAEoCRINCgVlcnJvchgDIAEoCRI6Cgtjb3JyZWxhdGlvbhgEIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyJ+Cg1DaGF0UnVuRmFpbGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDgoGc3RhdHVzGAIgASgJEg0KBWVycm9yGAMgASgJEjoKC2NvcnJlbGF0aW9uGAQgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIlUKF0NoYXRQcm92aWRlckNhbGxTdGFydGVkEjoKC2NvcnJlbGF0aW9uGAEgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIqIBCh9DaGF0UHJvdmlkZXJDYWxsTWV0YWRhdGFVcGRhdGVkEhMKC3N0b3BfcmVhc29uGAEgASgJEi4KBXVzYWdlGAIgASgLMh8ucGlub2NjaGlvLmNoYXRhcHAudjEuVXNhZ2VJbmZvEjoKC2NvcnJlbGF0aW9uGAMgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIvMBChhDaGF0UHJvdmlkZXJDYWxsRmluaXNoZWQSEwoLc3RvcF9yZWFzb24YASABKAkSFAoMZmluaXNoX2NsYXNzGAIgASgJEi4KBXVzYWdlGAMgASgLMh8ucGlub2NjaGlvLmNoYXRhcHAudjEuVXNhZ2VJbmZvEhgKC2R1cmF0aW9uX21zGAQgASgDSACIAQESFgoOaGFzX3Rvb2xfY2FsbHMYBSABKAgSOgoLY29ycmVsYXRpb24YBiABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm9CDgoMX2R1cmF0aW9uX21zIqkBChZDaGF0VGV4dFNlZ21lbnRTdGFydGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDAoEcm9sZRgCIAEoCRIOCgZwcm9tcHQYAyABKAkSDgoGc3RhdHVzGAQgASgJEhEKCXN0cmVhbWluZxgFIAEoCBI6Cgtjb3JyZWxhdGlvbhgGIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLOAQoNQ2hhdFRleHREZWx0YRISCgptZXNzYWdlX2lkGAEgASgJEgwKBHJvbGUYAiABKAkSDgoGcHJvbXB0GAMgASgJEg0KBWNodW5rGAQgASgJEgwKBHRleHQYBSABKAkSDwoHY29udGVudBgGIAEoCRIOCgZzdGF0dXMYByABKAkSEQoJc3RyZWFtaW5nGAggASgIEjoKC2NvcnJlbGF0aW9uGAkgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIu8BChdDaGF0VGV4dFNlZ21lbnRGaW5pc2hlZBISCgptZXNzYWdlX2lkGAEgASgJEgwKBHJvbGUYAiABKAkSDgoGcHJvbXB0GAMgASgJEgwKBHRleHQYBCABKAkSDwoHY29udGVudBgFIAEoCRIOCgZzdGF0dXMYBiABKAkSEQoJc3RyZWFtaW5nGAcgASgIEg0KBWZpbmFsGAggASgIEhUKDWZpbmlzaF9yZWFzb24YCSABKAkSOgoLY29ycmVsYXRpb24YCiABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8iyQEKG0NoYXRSZWFzb25pbmdTZWdtZW50U3RhcnRlZBISCgptZXNzYWdlX2lkGAEgASgJEhkKEXBhcmVudF9tZXNzYWdlX2lkGAIgASgJEgwKBHJvbGUYAyABKAkSDgoGc3RhdHVzGAQgASgJEhEKCXN0cmVhbWluZxgFIAEoCBIOCgZzb3VyY2UYBiABKAkSOgoLY29ycmVsYXRpb24YByABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8i7gEKEkNoYXRSZWFzb25pbmdEZWx0YRISCgptZXNzYWdlX2lkGAEgASgJEhkKEXBhcmVudF9tZXNzYWdlX2lkGAIgASgJEgwKBHJvbGUYAyABKAkSDQoFY2h1bmsYBCABKAkSDAoEdGV4dBgFIAEoCRIPCgdjb250ZW50GAYgASgJEg4KBnN0YXR1cxgHIAEoCRIRCglzdHJlYW1pbmcYCCABKAgSDgoGc291cmNlGAkgASgJEjoKC2NvcnJlbGF0aW9uGAogASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIoACChxDaGF0UmVhc29uaW5nU2VnbWVudEZpbmlzaGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSGQoRcGFyZW50X21lc3NhZ2VfaWQYAiABKAkSDAoEcm9sZRgDIAEoCRIMCgR0ZXh0GAQgASgJEg8KB2NvbnRlbnQYBSABKAkSDgoGc3RhdHVzGAYgASgJEhEKCXN0cmVhbWluZxgHIAEoCBIOCgZzb3VyY2UYCCABKAkSFQoNZmluaXNoX3JlYXNvbhgJIAEoCRI6Cgtjb3JyZWxhdGlvbhgKIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLAAQoTQ2hhdFRvb2xDYWxsU3RhcnRlZBISCgptZXNzYWdlX2lkGAEgASgJEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRIRCgl0b29sX25hbWUYAyABKAkSDQoFaW5wdXQYBCABKAkSEQoJZXhlY3V0aW5nGAUgASgIEg4KBnN0YXR1cxgGIAEoCRI6Cgtjb3JyZWxhdGlvbhgHIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLNAQoaQ2hhdFRvb2xDYWxsQXJndW1lbnRzRGVsdGESEgoKbWVzc2FnZV9pZBgBIAEoCRIUCgx0b29sX2NhbGxfaWQYAiABKAkSEQoJdG9vbF9uYW1lGAMgASgJEhcKD2FyZ3VtZW50c19kZWx0YRgEIAEoCRINCgVpbnB1dBgFIAEoCRIOCgZzdGF0dXMYBiABKAkSOgoLY29ycmVsYXRpb24YByABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8iwgEKFUNoYXRUb29sQ2FsbFJlcXVlc3RlZBISCgptZXNzYWdlX2lkGAEgASgJEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRIRCgl0b29sX25hbWUYAyABKAkSDQoFaW5wdXQYBCABKAkSEQoJZXhlY3V0aW5nGAUgASgIEg4KBnN0YXR1cxgGIAEoCRI6Cgtjb3JyZWxhdGlvbhgHIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLFAQoYQ2hhdFRvb2xFeGVjdXRpb25TdGFydGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRINCgVpbnB1dBgEIAEoCRIRCglleGVjdXRpbmcYBSABKAgSDgoGc3RhdHVzGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIq4BChNDaGF0VG9vbFJlc3VsdFJlYWR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRIOCgZyZXN1bHQYBCABKAkSDgoGc3RhdHVzGAUgASgJEjoKC2NvcnJlbGF0aW9uGAYgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIp8BChRDaGF0VG9vbENhbGxGaW5pc2hlZBISCgptZXNzYWdlX2lkGAEgASgJEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRIRCgl0b29sX25hbWUYAyABKAkSDgoGc3RhdHVzGAQgASgJEjoKC2NvcnJlbGF0aW9uGAUgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvInoKF0NoYXRVc2VyTWVzc2FnZUFjY2VwdGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDAoEcm9sZRgCIAEoCRIOCgZwcm9tcHQYAyABKAkSDAoEdGV4dBgEIAEoCRIPCgdjb250ZW50GAUgASgJEg4KBnN0YXR1cxgGIAEoCSKjAgoRQ2hhdE1lc3NhZ2VFbnRpdHkSEgoKbWVzc2FnZV9pZBgBIAEoCRIMCgRyb2xlGAIgASgJEg4KBnByb21wdBgDIAEoCRIMCgR0ZXh0GAQgASgJEg8KB2NvbnRlbnQYBSABKAkSDgoGc3RhdHVzGAYgASgJEhEKCXN0cmVhbWluZxgHIAEoCBINCgVlcnJvchgIIAEoCRIZChFwYXJlbnRfbWVzc2FnZV9pZBgJIAEoCRIPCgdzZWdtZW50GAogASgFEhQKDHNlZ21lbnRfdHlwZRgLIAEoCRINCgVmaW5hbBgMIAEoCBI6Cgtjb3JyZWxhdGlvbhgNIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyJ8ChZBZ2VudE1vZGVQcmV2aWV3VXBkYXRlEhIKCm1lc3NhZ2VfaWQYASABKAkSFgoOY2FuZGlkYXRlX21vZGUYAiABKAkSEAoIYW5hbHlzaXMYAyABKAkSEwoLcGFyc2Vfc3RhdGUYBCABKAkSDwoHcHJldmlldxgFIAEoCCJ6ChhBZ2VudE1vZGVDb21taXR0ZWRVcGRhdGUSEgoKbWVzc2FnZV9pZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRmcm9tGAMgASgJEgoKAnRvGAQgASgJEhAKCGFuYWx5c2lzGAUgASgJEg8KB3ByZXZpZXcYBiABKAgiLQoXQWdlbnRNb2RlUHJldmlld0NsZWFyZWQSEgoKbWVzc2FnZV9pZBgBIAEoCSJxCg9BZ2VudE1vZGVFbnRpdHkSEgoKbWVzc2FnZV9pZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRmcm9tGAMgASgJEgoKAnRvGAQgASgJEhAKCGFuYWx5c2lzGAUgASgJEg8KB3ByZXZpZXcYBiABKAgiuwEKDlRvb2xDYWxsRW50aXR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRINCgVpbnB1dBgEIAEoCRIRCglleGVjdXRpbmcYBSABKAgSDgoGc3RhdHVzGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIqsBChBUb29sUmVzdWx0RW50aXR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRIOCgZyZXN1bHQYBCABKAkSDgoGc3RhdHVzGAUgASgJEjoKC2NvcnJlbGF0aW9uGAYgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvQldaVWdpdGh1Yi5jb20vZ28tZ28tZ29sZW1zL3Bpbm9jY2hpby9wa2cvY2hhdGFwcC9wYi9wcm90by9waW5vY2NoaW8vY2hhdGFwcC92MTtjaGF0YXBwdjFiBnByb3RvMw");
+  fileDesc("CiVwcm90by9waW5vY2NoaW8vY2hhdGFwcC92MS9jaGF0LnByb3RvEhRwaW5vY2NoaW8uY2hhdGFwcC52MSJUChVTdGFydEluZmVyZW5jZUNvbW1hbmQSDgoGcHJvbXB0GAEgASgJEhcKD2lkZW1wb3RlbmN5X2tleRgCIAEoCRISCgpyZXF1ZXN0X2lkGAMgASgJIhYKFFN0b3BJbmZlcmVuY2VDb21tYW5kIpUBCglVc2FnZUluZm8SFAoMaW5wdXRfdG9rZW5zGAEgASgFEhUKDW91dHB1dF90b2tlbnMYAiABKAUSFQoNY2FjaGVkX3Rva2VucxgDIAEoBRIjChtjYWNoZV9jcmVhdGlvbl9pbnB1dF90b2tlbnMYBCABKAUSHwoXY2FjaGVfcmVhZF9pbnB1dF90b2tlbnMYBSABKAUiigEKD0NvcnJlbGF0aW9uSW5mbxISCgpzZXNzaW9uX2lkGAEgASgJEg4KBnJ1bl9pZBgCIAEoCRIPCgd0dXJuX2lkGAQgASgJEhgKEHByb3ZpZGVyX2NhbGxfaWQYBSABKAkSEgoKc2VnbWVudF9pZBgPIAEoCRIUCgx0b29sX2NhbGxfaWQYEyABKAkicAoOQ2hhdFJ1blN0YXJ0ZWQSEgoKbWVzc2FnZV9pZBgBIAEoCRIOCgZwcm9tcHQYAiABKAkSOgoLY29ycmVsYXRpb24YAyABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8iqgEKD0NoYXRSdW5GaW5pc2hlZBISCgptZXNzYWdlX2lkGAEgASgJEg4KBnN0YXR1cxgCIAEoCRINCgVlcnJvchgDIAEoCRIYCgtkdXJhdGlvbl9tcxgEIAEoA0gAiAEBEjoKC2NvcnJlbGF0aW9uGAUgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvQg4KDF9kdXJhdGlvbl9tcyJ/Cg5DaGF0UnVuU3RvcHBlZBISCgptZXNzYWdlX2lkGAEgASgJEg4KBnN0YXR1cxgCIAEoCRINCgVlcnJvchgDIAEoCRI6Cgtjb3JyZWxhdGlvbhgEIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyJ+Cg1DaGF0UnVuRmFpbGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDgoGc3RhdHVzGAIgASgJEg0KBWVycm9yGAMgASgJEjoKC2NvcnJlbGF0aW9uGAQgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIlUKF0NoYXRQcm92aWRlckNhbGxTdGFydGVkEjoKC2NvcnJlbGF0aW9uGAEgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIqIBCh9DaGF0UHJvdmlkZXJDYWxsTWV0YWRhdGFVcGRhdGVkEhMKC3N0b3BfcmVhc29uGAEgASgJEi4KBXVzYWdlGAIgASgLMh8ucGlub2NjaGlvLmNoYXRhcHAudjEuVXNhZ2VJbmZvEjoKC2NvcnJlbGF0aW9uGAMgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIvMBChhDaGF0UHJvdmlkZXJDYWxsRmluaXNoZWQSEwoLc3RvcF9yZWFzb24YASABKAkSFAoMZmluaXNoX2NsYXNzGAIgASgJEi4KBXVzYWdlGAMgASgLMh8ucGlub2NjaGlvLmNoYXRhcHAudjEuVXNhZ2VJbmZvEhgKC2R1cmF0aW9uX21zGAQgASgDSACIAQESFgoOaGFzX3Rvb2xfY2FsbHMYBSABKAgSOgoLY29ycmVsYXRpb24YBiABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm9CDgoMX2R1cmF0aW9uX21zIqkBChZDaGF0VGV4dFNlZ21lbnRTdGFydGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDAoEcm9sZRgCIAEoCRIOCgZwcm9tcHQYAyABKAkSDgoGc3RhdHVzGAQgASgJEhEKCXN0cmVhbWluZxgFIAEoCBI6Cgtjb3JyZWxhdGlvbhgGIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyKvAgoNQ2hhdFRleHRQYXRjaBISCgptZXNzYWdlX2lkGAEgASgJEgwKBHJvbGUYAiABKAkSEQoJc3RyZWFtX2lkGAMgASgJEhAKCHNlcXVlbmNlGAQgASgEEg4KBm9mZnNldBgFIAEoBBIMCgR0ZXh0GAYgASgJEjcKBG1vZGUYByABKA4yKS5waW5vY2NoaW8uY2hhdGFwcC52MS5DaGF0U3RyZWFtUGF0Y2hNb2RlEg4KBnN0YXR1cxgIIAEoCRINCgVmaW5hbBgJIAEoCBIVCg1maW5pc2hfcmVhc29uGAogASgJEg4KBnByb21wdBgLIAEoCRI6Cgtjb3JyZWxhdGlvbhgMIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLvAQoXQ2hhdFRleHRTZWdtZW50RmluaXNoZWQSEgoKbWVzc2FnZV9pZBgBIAEoCRIMCgRyb2xlGAIgASgJEg4KBnByb21wdBgDIAEoCRIMCgR0ZXh0GAQgASgJEg8KB2NvbnRlbnQYBSABKAkSDgoGc3RhdHVzGAYgASgJEhEKCXN0cmVhbWluZxgHIAEoCBINCgVmaW5hbBgIIAEoCBIVCg1maW5pc2hfcmVhc29uGAkgASgJEjoKC2NvcnJlbGF0aW9uGAogASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIskBChtDaGF0UmVhc29uaW5nU2VnbWVudFN0YXJ0ZWQSEgoKbWVzc2FnZV9pZBgBIAEoCRIZChFwYXJlbnRfbWVzc2FnZV9pZBgCIAEoCRIMCgRyb2xlGAMgASgJEg4KBnN0YXR1cxgEIAEoCRIRCglzdHJlYW1pbmcYBSABKAgSDgoGc291cmNlGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIs8CChJDaGF0UmVhc29uaW5nUGF0Y2gSEgoKbWVzc2FnZV9pZBgBIAEoCRIZChFwYXJlbnRfbWVzc2FnZV9pZBgCIAEoCRIMCgRyb2xlGAMgASgJEhEKCXN0cmVhbV9pZBgEIAEoCRIQCghzZXF1ZW5jZRgFIAEoBBIOCgZvZmZzZXQYBiABKAQSDAoEdGV4dBgHIAEoCRI3CgRtb2RlGAggASgOMikucGlub2NjaGlvLmNoYXRhcHAudjEuQ2hhdFN0cmVhbVBhdGNoTW9kZRIOCgZzdGF0dXMYCSABKAkSDQoFZmluYWwYCiABKAgSDgoGc291cmNlGAsgASgJEhUKDWZpbmlzaF9yZWFzb24YDCABKAkSOgoLY29ycmVsYXRpb24YDSABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8igAIKHENoYXRSZWFzb25pbmdTZWdtZW50RmluaXNoZWQSEgoKbWVzc2FnZV9pZBgBIAEoCRIZChFwYXJlbnRfbWVzc2FnZV9pZBgCIAEoCRIMCgRyb2xlGAMgASgJEgwKBHRleHQYBCABKAkSDwoHY29udGVudBgFIAEoCRIOCgZzdGF0dXMYBiABKAkSEQoJc3RyZWFtaW5nGAcgASgIEg4KBnNvdXJjZRgIIAEoCRIVCg1maW5pc2hfcmVhc29uGAkgASgJEjoKC2NvcnJlbGF0aW9uGAogASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIsABChNDaGF0VG9vbENhbGxTdGFydGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRINCgVpbnB1dBgEIAEoCRIRCglleGVjdXRpbmcYBSABKAgSDgoGc3RhdHVzGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIrECChZDaGF0VG9vbEFyZ3VtZW50c1BhdGNoEhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRIRCglzdHJlYW1faWQYBCABKAkSEAoIc2VxdWVuY2UYBSABKAQSDgoGb2Zmc2V0GAYgASgEEhEKCWFyZ3VtZW50cxgHIAEoCRI3CgRtb2RlGAggASgOMikucGlub2NjaGlvLmNoYXRhcHAudjEuQ2hhdFN0cmVhbVBhdGNoTW9kZRIOCgZzdGF0dXMYCSABKAkSDQoFZmluYWwYCiABKAgSOgoLY29ycmVsYXRpb24YCyABKAsyJS5waW5vY2NoaW8uY2hhdGFwcC52MS5Db3JyZWxhdGlvbkluZm8iwgEKFUNoYXRUb29sQ2FsbFJlcXVlc3RlZBISCgptZXNzYWdlX2lkGAEgASgJEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRIRCgl0b29sX25hbWUYAyABKAkSDQoFaW5wdXQYBCABKAkSEQoJZXhlY3V0aW5nGAUgASgIEg4KBnN0YXR1cxgGIAEoCRI6Cgtjb3JyZWxhdGlvbhgHIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyLFAQoYQ2hhdFRvb2xFeGVjdXRpb25TdGFydGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRINCgVpbnB1dBgEIAEoCRIRCglleGVjdXRpbmcYBSABKAgSDgoGc3RhdHVzGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIq4BChNDaGF0VG9vbFJlc3VsdFJlYWR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRIOCgZyZXN1bHQYBCABKAkSDgoGc3RhdHVzGAUgASgJEjoKC2NvcnJlbGF0aW9uGAYgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIp8BChRDaGF0VG9vbENhbGxGaW5pc2hlZBISCgptZXNzYWdlX2lkGAEgASgJEhQKDHRvb2xfY2FsbF9pZBgCIAEoCRIRCgl0b29sX25hbWUYAyABKAkSDgoGc3RhdHVzGAQgASgJEjoKC2NvcnJlbGF0aW9uGAUgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvInoKF0NoYXRVc2VyTWVzc2FnZUFjY2VwdGVkEhIKCm1lc3NhZ2VfaWQYASABKAkSDAoEcm9sZRgCIAEoCRIOCgZwcm9tcHQYAyABKAkSDAoEdGV4dBgEIAEoCRIPCgdjb250ZW50GAUgASgJEg4KBnN0YXR1cxgGIAEoCSKjAgoRQ2hhdE1lc3NhZ2VFbnRpdHkSEgoKbWVzc2FnZV9pZBgBIAEoCRIMCgRyb2xlGAIgASgJEg4KBnByb21wdBgDIAEoCRIMCgR0ZXh0GAQgASgJEg8KB2NvbnRlbnQYBSABKAkSDgoGc3RhdHVzGAYgASgJEhEKCXN0cmVhbWluZxgHIAEoCBINCgVlcnJvchgIIAEoCRIZChFwYXJlbnRfbWVzc2FnZV9pZBgJIAEoCRIPCgdzZWdtZW50GAogASgFEhQKDHNlZ21lbnRfdHlwZRgLIAEoCRINCgVmaW5hbBgMIAEoCBI6Cgtjb3JyZWxhdGlvbhgNIAEoCzIlLnBpbm9jY2hpby5jaGF0YXBwLnYxLkNvcnJlbGF0aW9uSW5mbyJ8ChZBZ2VudE1vZGVQcmV2aWV3VXBkYXRlEhIKCm1lc3NhZ2VfaWQYASABKAkSFgoOY2FuZGlkYXRlX21vZGUYAiABKAkSEAoIYW5hbHlzaXMYAyABKAkSEwoLcGFyc2Vfc3RhdGUYBCABKAkSDwoHcHJldmlldxgFIAEoCCJ6ChhBZ2VudE1vZGVDb21taXR0ZWRVcGRhdGUSEgoKbWVzc2FnZV9pZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRmcm9tGAMgASgJEgoKAnRvGAQgASgJEhAKCGFuYWx5c2lzGAUgASgJEg8KB3ByZXZpZXcYBiABKAgiLQoXQWdlbnRNb2RlUHJldmlld0NsZWFyZWQSEgoKbWVzc2FnZV9pZBgBIAEoCSJxCg9BZ2VudE1vZGVFbnRpdHkSEgoKbWVzc2FnZV9pZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRmcm9tGAMgASgJEgoKAnRvGAQgASgJEhAKCGFuYWx5c2lzGAUgASgJEg8KB3ByZXZpZXcYBiABKAgiuwEKDlRvb2xDYWxsRW50aXR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRINCgVpbnB1dBgEIAEoCRIRCglleGVjdXRpbmcYBSABKAgSDgoGc3RhdHVzGAYgASgJEjoKC2NvcnJlbGF0aW9uGAcgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvIqsBChBUb29sUmVzdWx0RW50aXR5EhIKCm1lc3NhZ2VfaWQYASABKAkSFAoMdG9vbF9jYWxsX2lkGAIgASgJEhEKCXRvb2xfbmFtZRgDIAEoCRIOCgZyZXN1bHQYBCABKAkSDgoGc3RhdHVzGAUgASgJEjoKC2NvcnJlbGF0aW9uGAYgASgLMiUucGlub2NjaGlvLmNoYXRhcHAudjEuQ29ycmVsYXRpb25JbmZvKqkBChNDaGF0U3RyZWFtUGF0Y2hNb2RlEiYKIkNIQVRfU1RSRUFNX1BBVENIX01PREVfVU5TUEVDSUZJRUQQABIhCh1DSEFUX1NUUkVBTV9QQVRDSF9NT0RFX0FQUEVORBABEiMKH0NIQVRfU1RSRUFNX1BBVENIX01PREVfU05BUFNIT1QQAhIiCh5DSEFUX1NUUkVBTV9QQVRDSF9NT0RFX1JFUExBQ0UQA0JXWlVnaXRodWIuY29tL2dvLWdvLWdvbGVtcy9waW5vY2NoaW8vcGtnL2NoYXRhcHAvcGIvcHJvdG8vcGlub2NjaGlvL2NoYXRhcHAvdjE7Y2hhdGFwcHYxYgZwcm90bzM");
 
 /**
  * @generated from message pinocchio.chatapp.v1.StartInferenceCommand
@@ -388,9 +388,9 @@ export const ChatTextSegmentStartedSchema: GenMessage<ChatTextSegmentStarted> = 
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 11);
 
 /**
- * @generated from message pinocchio.chatapp.v1.ChatTextDelta
+ * @generated from message pinocchio.chatapp.v1.ChatTextPatch
  */
-export type ChatTextDelta = Message<"pinocchio.chatapp.v1.ChatTextDelta"> & {
+export type ChatTextPatch = Message<"pinocchio.chatapp.v1.ChatTextPatch"> & {
   /**
    * @generated from field: string message_id = 1;
    */
@@ -402,46 +402,61 @@ export type ChatTextDelta = Message<"pinocchio.chatapp.v1.ChatTextDelta"> & {
   role: string;
 
   /**
-   * @generated from field: string prompt = 3;
+   * @generated from field: string stream_id = 3;
    */
-  prompt: string;
+  streamId: string;
 
   /**
-   * @generated from field: string chunk = 4;
+   * @generated from field: uint64 sequence = 4;
    */
-  chunk: string;
+  sequence: bigint;
 
   /**
-   * @generated from field: string text = 5;
+   * @generated from field: uint64 offset = 5;
+   */
+  offset: bigint;
+
+  /**
+   * @generated from field: string text = 6;
    */
   text: string;
 
   /**
-   * @generated from field: string content = 6;
+   * @generated from field: pinocchio.chatapp.v1.ChatStreamPatchMode mode = 7;
    */
-  content: string;
+  mode: ChatStreamPatchMode;
 
   /**
-   * @generated from field: string status = 7;
+   * @generated from field: string status = 8;
    */
   status: string;
 
   /**
-   * @generated from field: bool streaming = 8;
+   * @generated from field: bool final = 9;
    */
-  streaming: boolean;
+  final: boolean;
 
   /**
-   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 9;
+   * @generated from field: string finish_reason = 10;
+   */
+  finishReason: string;
+
+  /**
+   * @generated from field: string prompt = 11;
+   */
+  prompt: string;
+
+  /**
+   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 12;
    */
   correlation?: CorrelationInfo | undefined;
 };
 
 /**
- * Describes the message pinocchio.chatapp.v1.ChatTextDelta.
- * Use `create(ChatTextDeltaSchema)` to create a new message.
+ * Describes the message pinocchio.chatapp.v1.ChatTextPatch.
+ * Use `create(ChatTextPatchSchema)` to create a new message.
  */
-export const ChatTextDeltaSchema: GenMessage<ChatTextDelta> = /*@__PURE__*/
+export const ChatTextPatchSchema: GenMessage<ChatTextPatch> = /*@__PURE__*/
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 12);
 
 /**
@@ -554,9 +569,9 @@ export const ChatReasoningSegmentStartedSchema: GenMessage<ChatReasoningSegmentS
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 14);
 
 /**
- * @generated from message pinocchio.chatapp.v1.ChatReasoningDelta
+ * @generated from message pinocchio.chatapp.v1.ChatReasoningPatch
  */
-export type ChatReasoningDelta = Message<"pinocchio.chatapp.v1.ChatReasoningDelta"> & {
+export type ChatReasoningPatch = Message<"pinocchio.chatapp.v1.ChatReasoningPatch"> & {
   /**
    * @generated from field: string message_id = 1;
    */
@@ -573,46 +588,61 @@ export type ChatReasoningDelta = Message<"pinocchio.chatapp.v1.ChatReasoningDelt
   role: string;
 
   /**
-   * @generated from field: string chunk = 4;
+   * @generated from field: string stream_id = 4;
    */
-  chunk: string;
+  streamId: string;
 
   /**
-   * @generated from field: string text = 5;
+   * @generated from field: uint64 sequence = 5;
+   */
+  sequence: bigint;
+
+  /**
+   * @generated from field: uint64 offset = 6;
+   */
+  offset: bigint;
+
+  /**
+   * @generated from field: string text = 7;
    */
   text: string;
 
   /**
-   * @generated from field: string content = 6;
+   * @generated from field: pinocchio.chatapp.v1.ChatStreamPatchMode mode = 8;
    */
-  content: string;
+  mode: ChatStreamPatchMode;
 
   /**
-   * @generated from field: string status = 7;
+   * @generated from field: string status = 9;
    */
   status: string;
 
   /**
-   * @generated from field: bool streaming = 8;
+   * @generated from field: bool final = 10;
    */
-  streaming: boolean;
+  final: boolean;
 
   /**
-   * @generated from field: string source = 9;
+   * @generated from field: string source = 11;
    */
   source: string;
 
   /**
-   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 10;
+   * @generated from field: string finish_reason = 12;
+   */
+  finishReason: string;
+
+  /**
+   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 13;
    */
   correlation?: CorrelationInfo | undefined;
 };
 
 /**
- * Describes the message pinocchio.chatapp.v1.ChatReasoningDelta.
- * Use `create(ChatReasoningDeltaSchema)` to create a new message.
+ * Describes the message pinocchio.chatapp.v1.ChatReasoningPatch.
+ * Use `create(ChatReasoningPatchSchema)` to create a new message.
  */
-export const ChatReasoningDeltaSchema: GenMessage<ChatReasoningDelta> = /*@__PURE__*/
+export const ChatReasoningPatchSchema: GenMessage<ChatReasoningPatch> = /*@__PURE__*/
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 15);
 
 /**
@@ -725,9 +755,9 @@ export const ChatToolCallStartedSchema: GenMessage<ChatToolCallStarted> = /*@__P
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 17);
 
 /**
- * @generated from message pinocchio.chatapp.v1.ChatToolCallArgumentsDelta
+ * @generated from message pinocchio.chatapp.v1.ChatToolArgumentsPatch
  */
-export type ChatToolCallArgumentsDelta = Message<"pinocchio.chatapp.v1.ChatToolCallArgumentsDelta"> & {
+export type ChatToolArgumentsPatch = Message<"pinocchio.chatapp.v1.ChatToolArgumentsPatch"> & {
   /**
    * @generated from field: string message_id = 1;
    */
@@ -744,31 +774,51 @@ export type ChatToolCallArgumentsDelta = Message<"pinocchio.chatapp.v1.ChatToolC
   toolName: string;
 
   /**
-   * @generated from field: string arguments_delta = 4;
+   * @generated from field: string stream_id = 4;
    */
-  argumentsDelta: string;
+  streamId: string;
 
   /**
-   * @generated from field: string input = 5;
+   * @generated from field: uint64 sequence = 5;
    */
-  input: string;
+  sequence: bigint;
 
   /**
-   * @generated from field: string status = 6;
+   * @generated from field: uint64 offset = 6;
+   */
+  offset: bigint;
+
+  /**
+   * @generated from field: string arguments = 7;
+   */
+  arguments: string;
+
+  /**
+   * @generated from field: pinocchio.chatapp.v1.ChatStreamPatchMode mode = 8;
+   */
+  mode: ChatStreamPatchMode;
+
+  /**
+   * @generated from field: string status = 9;
    */
   status: string;
 
   /**
-   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 7;
+   * @generated from field: bool final = 10;
+   */
+  final: boolean;
+
+  /**
+   * @generated from field: pinocchio.chatapp.v1.CorrelationInfo correlation = 11;
    */
   correlation?: CorrelationInfo | undefined;
 };
 
 /**
- * Describes the message pinocchio.chatapp.v1.ChatToolCallArgumentsDelta.
- * Use `create(ChatToolCallArgumentsDeltaSchema)` to create a new message.
+ * Describes the message pinocchio.chatapp.v1.ChatToolArgumentsPatch.
+ * Use `create(ChatToolArgumentsPatchSchema)` to create a new message.
  */
-export const ChatToolCallArgumentsDeltaSchema: GenMessage<ChatToolCallArgumentsDelta> = /*@__PURE__*/
+export const ChatToolArgumentsPatchSchema: GenMessage<ChatToolArgumentsPatch> = /*@__PURE__*/
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 18);
 
 /**
@@ -1289,4 +1339,35 @@ export type ToolResultEntity = Message<"pinocchio.chatapp.v1.ToolResultEntity"> 
  */
 export const ToolResultEntitySchema: GenMessage<ToolResultEntity> = /*@__PURE__*/
   messageDesc(file_proto_pinocchio_chatapp_v1_chat, 30);
+
+/**
+ * @generated from enum pinocchio.chatapp.v1.ChatStreamPatchMode
+ */
+export enum ChatStreamPatchMode {
+  /**
+   * @generated from enum value: CHAT_STREAM_PATCH_MODE_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: CHAT_STREAM_PATCH_MODE_APPEND = 1;
+   */
+  APPEND = 1,
+
+  /**
+   * @generated from enum value: CHAT_STREAM_PATCH_MODE_SNAPSHOT = 2;
+   */
+  SNAPSHOT = 2,
+
+  /**
+   * @generated from enum value: CHAT_STREAM_PATCH_MODE_REPLACE = 3;
+   */
+  REPLACE = 3,
+}
+
+/**
+ * Describes the enum pinocchio.chatapp.v1.ChatStreamPatchMode.
+ */
+export const ChatStreamPatchModeSchema: GenEnum<ChatStreamPatchMode> = /*@__PURE__*/
+  enumDesc(file_proto_pinocchio_chatapp_v1_chat, 0);
 

--- a/cmd/web-chat/web/src/store/timelineSlice.ts
+++ b/cmd/web-chat/web/src/store/timelineSlice.ts
@@ -23,15 +23,35 @@ function parseJsonOrRaw(value: string): unknown {
   }
 }
 
-function mergePropsWithPatches(existingProps: any, incomingProps: any, contentPatch?: string, inputRawPatch?: string): any {
+function applyStreamPatch(previous: string, patch: string, mode: unknown): string {
+  if (
+    mode === 'CHAT_STREAM_PATCH_MODE_SNAPSHOT' ||
+    mode === 'CHAT_STREAM_PATCH_MODE_REPLACE' ||
+    mode === 'SNAPSHOT' ||
+    mode === 'REPLACE' ||
+    mode === 2 ||
+    mode === 3
+  ) {
+    return patch;
+  }
+  return `${previous}${patch}`;
+}
+
+function mergePropsWithPatches(
+  existingProps: any,
+  incomingProps: any,
+  contentPatch?: string,
+  inputRawPatch?: string,
+  patchMode?: unknown,
+): any {
   const merged = { ...(existingProps ?? {}), ...(incomingProps ?? {}) };
   if (contentPatch !== undefined) {
     const previous = typeof existingProps?.content === 'string' ? existingProps.content : '';
-    merged.content = previous + contentPatch;
+    merged.content = applyStreamPatch(previous, contentPatch, patchMode);
   }
   if (inputRawPatch !== undefined) {
     const previous = typeof existingProps?.inputRaw === 'string' ? existingProps.inputRaw : '';
-    const inputRaw = previous + inputRawPatch;
+    const inputRaw = applyStreamPatch(previous, inputRawPatch, patchMode);
     merged.inputRaw = inputRaw;
     merged.input = parseJsonOrRaw(inputRaw);
   }
@@ -43,11 +63,13 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
   const incomingProps = { ...(e.props ?? {}) };
   const contentPatch = typeof incomingProps.contentPatch === 'string' ? incomingProps.contentPatch : undefined;
   const inputRawPatch = typeof incomingProps.inputRawPatch === 'string' ? incomingProps.inputRawPatch : undefined;
+  const patchMode = incomingProps.patchMode;
   delete incomingProps.contentPatch;
   delete incomingProps.inputRawPatch;
+  delete incomingProps.patchMode;
   if (!existing) {
     if (!createIfMissing) return;
-    state.byId[e.id] = { ...e, props: mergePropsWithPatches({}, incomingProps, contentPatch, inputRawPatch) };
+    state.byId[e.id] = { ...e, props: mergePropsWithPatches({}, incomingProps, contentPatch, inputRawPatch, patchMode) };
     state.order.push(e.id);
     return;
   }
@@ -63,7 +85,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
       createdAt: e.createdAt || existing.createdAt,
       kind: e.kind || existing.kind,
       version: incomingVersion,
-      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
+      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch, patchMode),
     };
     return;
   }
@@ -71,7 +93,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
     state.byId[e.id] = {
       ...existing,
       updatedAt: e.updatedAt ?? existing.updatedAt,
-      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
+      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch, patchMode),
     };
     return;
   }
@@ -80,7 +102,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
     ...e,
     createdAt: existing.createdAt,
     kind: e.kind || existing.kind,
-    props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
+    props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch, patchMode),
   };
 }
 

--- a/cmd/web-chat/web/src/store/timelineSlice.ts
+++ b/cmd/web-chat/web/src/store/timelineSlice.ts
@@ -15,14 +15,42 @@ type TimelineState = {
   order: string[];
 };
 
+function parseJsonOrRaw(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function mergePropsWithPatches(existingProps: any, incomingProps: any, contentPatch?: string, inputRawPatch?: string): any {
+  const merged = { ...(existingProps ?? {}), ...(incomingProps ?? {}) };
+  if (contentPatch !== undefined) {
+    const previous = typeof existingProps?.content === 'string' ? existingProps.content : '';
+    merged.content = previous + contentPatch;
+  }
+  if (inputRawPatch !== undefined) {
+    const previous = typeof existingProps?.inputRaw === 'string' ? existingProps.inputRaw : '';
+    const inputRaw = previous + inputRawPatch;
+    merged.inputRaw = inputRaw;
+    merged.input = parseJsonOrRaw(inputRaw);
+  }
+  return merged;
+}
+
 function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMissing: boolean) {
-  if (!state.byId[e.id]) {
+  const existing = state.byId[e.id];
+  const incomingProps = { ...(e.props ?? {}) };
+  const contentPatch = typeof incomingProps.contentPatch === 'string' ? incomingProps.contentPatch : undefined;
+  const inputRawPatch = typeof incomingProps.inputRawPatch === 'string' ? incomingProps.inputRawPatch : undefined;
+  delete incomingProps.contentPatch;
+  delete incomingProps.inputRawPatch;
+  if (!existing) {
     if (!createIfMissing) return;
-    state.byId[e.id] = e;
+    state.byId[e.id] = { ...e, props: mergePropsWithPatches({}, incomingProps, contentPatch, inputRawPatch) };
     state.order.push(e.id);
     return;
   }
-  const existing = state.byId[e.id];
   const incomingVersion = typeof e.version === 'number' && Number.isFinite(e.version) ? e.version : 0;
   const existingVersion = typeof existing.version === 'number' && Number.isFinite(existing.version) ? existing.version : 0;
   if (incomingVersion > 0) {
@@ -35,7 +63,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
       createdAt: e.createdAt || existing.createdAt,
       kind: e.kind || existing.kind,
       version: incomingVersion,
-      props: { ...(existing.props ?? {}), ...(e.props ?? {}) },
+      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
     };
     return;
   }
@@ -43,7 +71,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
     state.byId[e.id] = {
       ...existing,
       updatedAt: e.updatedAt ?? existing.updatedAt,
-      props: { ...(existing.props ?? {}), ...(e.props ?? {}) },
+      props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
     };
     return;
   }
@@ -52,7 +80,7 @@ function mergeTimelineEntity(state: TimelineState, e: TimelineEntity, createIfMi
     ...e,
     createdAt: existing.createdAt,
     kind: e.kind || existing.kind,
-    props: { ...(existing.props ?? {}), ...(e.props ?? {}) },
+    props: mergePropsWithPatches(existing.props, incomingProps, contentPatch, inputRawPatch),
   };
 }
 

--- a/cmd/web-chat/web/src/ws/chatappPayloads.ts
+++ b/cmd/web-chat/web/src/ws/chatappPayloads.ts
@@ -6,17 +6,17 @@ import type {
   ChatProviderCallFinished,
   ChatProviderCallMetadataUpdated,
   ChatProviderCallStarted,
-  ChatReasoningDelta,
+  ChatReasoningPatch,
   ChatReasoningSegmentFinished,
   ChatReasoningSegmentStarted,
   ChatRunFailed,
   ChatRunFinished,
   ChatRunStarted,
   ChatRunStopped,
-  ChatTextDelta,
+  ChatTextPatch,
   ChatTextSegmentFinished,
   ChatTextSegmentStarted,
-  ChatToolCallArgumentsDelta,
+  ChatToolArgumentsPatch,
   ChatToolCallFinished,
   ChatToolCallRequested,
   ChatToolCallStarted,
@@ -31,17 +31,17 @@ import {
   ChatProviderCallFinishedSchema,
   ChatProviderCallMetadataUpdatedSchema,
   ChatProviderCallStartedSchema,
-  ChatReasoningDeltaSchema,
+  ChatReasoningPatchSchema,
   ChatReasoningSegmentFinishedSchema,
   ChatReasoningSegmentStartedSchema,
   ChatRunFailedSchema,
   ChatRunFinishedSchema,
   ChatRunStartedSchema,
   ChatRunStoppedSchema,
-  ChatTextDeltaSchema,
+  ChatTextPatchSchema,
   ChatTextSegmentFinishedSchema,
   ChatTextSegmentStartedSchema,
-  ChatToolCallArgumentsDeltaSchema,
+  ChatToolArgumentsPatchSchema,
   ChatToolCallFinishedSchema,
   ChatToolCallRequestedSchema,
   ChatToolCallStartedSchema,
@@ -51,13 +51,13 @@ import {
 } from '../chatapp/pb/proto/pinocchio/chatapp/v1/chat_pb';
 import { asRecord, asString, type CanonicalFrame } from './protocol';
 
-export type ChatTextUIEventName = 'ChatUserMessageAccepted' | 'ChatTextSegmentStarted' | 'ChatTextDelta' | 'ChatTextSegmentFinished';
+export type ChatTextUIEventName = 'ChatUserMessageAccepted' | 'ChatTextSegmentStarted' | 'ChatTextPatch' | 'ChatTextSegmentFinished';
 export type ChatRunUIEventName = 'ChatRunStarted' | 'ChatRunFinished' | 'ChatRunStopped' | 'ChatRunFailed';
 export type ProviderCallUIEventName = 'ChatProviderCallStarted' | 'ChatProviderCallMetadataUpdated' | 'ChatProviderCallFinished';
-export type ReasoningUIEventName = 'ChatReasoningSegmentStarted' | 'ChatReasoningDelta' | 'ChatReasoningSegmentFinished';
+export type ReasoningUIEventName = 'ChatReasoningSegmentStarted' | 'ChatReasoningPatch' | 'ChatReasoningSegmentFinished';
 export type ToolUIEventName =
   | 'ChatToolCallStarted'
-  | 'ChatToolCallArgumentsDelta'
+  | 'ChatToolArgumentsPatch'
   | 'ChatToolCallRequested'
   | 'ChatToolExecutionStarted'
   | 'ChatToolResultReady'
@@ -74,13 +74,13 @@ export type KnownUIEvent =
   | { name: 'ChatProviderCallMetadataUpdated'; payload: ChatProviderCallMetadataUpdated }
   | { name: 'ChatProviderCallFinished'; payload: ChatProviderCallFinished }
   | { name: 'ChatTextSegmentStarted'; payload: ChatTextSegmentStarted }
-  | { name: 'ChatTextDelta'; payload: ChatTextDelta }
+  | { name: 'ChatTextPatch'; payload: ChatTextPatch }
   | { name: 'ChatTextSegmentFinished'; payload: ChatTextSegmentFinished }
   | { name: 'ChatReasoningSegmentStarted'; payload: ChatReasoningSegmentStarted }
-  | { name: 'ChatReasoningDelta'; payload: ChatReasoningDelta }
+  | { name: 'ChatReasoningPatch'; payload: ChatReasoningPatch }
   | { name: 'ChatReasoningSegmentFinished'; payload: ChatReasoningSegmentFinished }
   | { name: 'ChatToolCallStarted'; payload: ChatToolCallStarted }
-  | { name: 'ChatToolCallArgumentsDelta'; payload: ChatToolCallArgumentsDelta }
+  | { name: 'ChatToolArgumentsPatch'; payload: ChatToolArgumentsPatch }
   | { name: 'ChatToolCallRequested'; payload: ChatToolCallRequested }
   | { name: 'ChatToolExecutionStarted'; payload: ChatToolExecutionStarted }
   | { name: 'ChatToolResultReady'; payload: ChatToolResultReady }
@@ -115,20 +115,20 @@ export function decodeKnownUIEvent(frame: CanonicalFrame): KnownUIEvent | null {
         return { name, payload: fromJson(ChatProviderCallFinishedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatTextSegmentStarted':
         return { name, payload: fromJson(ChatTextSegmentStartedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
-      case 'ChatTextDelta':
-        return { name, payload: fromJson(ChatTextDeltaSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
+      case 'ChatTextPatch':
+        return { name, payload: fromJson(ChatTextPatchSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatTextSegmentFinished':
         return { name, payload: fromJson(ChatTextSegmentFinishedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatReasoningSegmentStarted':
         return { name, payload: fromJson(ChatReasoningSegmentStartedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
-      case 'ChatReasoningDelta':
-        return { name, payload: fromJson(ChatReasoningDeltaSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
+      case 'ChatReasoningPatch':
+        return { name, payload: fromJson(ChatReasoningPatchSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatReasoningSegmentFinished':
         return { name, payload: fromJson(ChatReasoningSegmentFinishedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatToolCallStarted':
         return { name, payload: fromJson(ChatToolCallStartedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
-      case 'ChatToolCallArgumentsDelta':
-        return { name, payload: fromJson(ChatToolCallArgumentsDeltaSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
+      case 'ChatToolArgumentsPatch':
+        return { name, payload: fromJson(ChatToolArgumentsPatchSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatToolCallRequested':
         return { name, payload: fromJson(ChatToolCallRequestedSchema, jsonPayload(frame), { ignoreUnknownFields: true }) };
       case 'ChatToolExecutionStarted':

--- a/cmd/web-chat/web/src/ws/timelineEvents.ts
+++ b/cmd/web-chat/web/src/ws/timelineEvents.ts
@@ -1,4 +1,4 @@
-import type { CorrelationInfo } from '../chatapp/pb/proto/pinocchio/chatapp/v1/chat_pb';
+import { ChatStreamPatchMode, type CorrelationInfo } from '../chatapp/pb/proto/pinocchio/chatapp/v1/chat_pb';
 import { appSlice } from '../store/appSlice';
 import type { AppDispatch } from '../store/store';
 import { type TimelineEntity, timelineSlice } from '../store/timelineSlice';
@@ -16,6 +16,22 @@ type TimelineMutation = {
 
 function visibleText(payload: { content?: string; text?: string }): string {
   return payload.content || payload.text || '';
+}
+
+function patchModeName(mode: unknown): string {
+  if (typeof mode === 'string' && mode.trim()) {
+    return mode;
+  }
+  switch (mode) {
+    case ChatStreamPatchMode.SNAPSHOT:
+      return 'CHAT_STREAM_PATCH_MODE_SNAPSHOT';
+    case ChatStreamPatchMode.REPLACE:
+      return 'CHAT_STREAM_PATCH_MODE_REPLACE';
+    case ChatStreamPatchMode.UNSPECIFIED:
+      return 'CHAT_STREAM_PATCH_MODE_UNSPECIFIED';
+    default:
+      return 'CHAT_STREAM_PATCH_MODE_APPEND';
+  }
 }
 
 function definedProps(props: Record<string, unknown>): Record<string, unknown> {
@@ -121,6 +137,7 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
           role: payload.role || 'assistant',
           prompt: payload.prompt,
           contentPatch: visibleText(payload),
+          patchMode: patchModeName(payload.mode),
           status: payload.status || 'streaming',
           streaming: !payload.final,
           parentMessageId: parentMessageId(messageId, ':text:'),
@@ -168,6 +185,7 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
         upsert: messageEntity(messageId, {
           role: 'thinking',
           contentPatch: visibleText(payload),
+          patchMode: patchModeName(payload.mode),
           status: payload.status || 'streaming',
           streaming: !payload.final,
           parentMessageId: payload.parentMessageId,
@@ -247,6 +265,7 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
       const isPatch = event.name === 'ChatToolArgumentsPatch';
       const hasInput = isPatch ? 'arguments' in payload && payload.arguments !== '' : 'input' in payload && payload.input !== '';
       const input = hasInput ? (isPatch && 'arguments' in payload ? payload.arguments : 'input' in payload ? payload.input : '') : '';
+      const patchMode = isPatch && 'mode' in payload ? payload.mode : undefined;
       const executing = 'executing' in payload ? payload.executing : false;
       return {
         upsert: toolCallEntity(
@@ -256,7 +275,7 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
             toolCallId: payload.toolCallId,
             name: payload.toolName,
             toolName: payload.toolName,
-            ...(hasInput ? (isPatch ? { inputRawPatch: input } : { input: parseToolInput(input), inputRaw: input }) : {}),
+            ...(hasInput ? (isPatch ? { inputRawPatch: input, patchMode: patchModeName(patchMode) } : { input: parseToolInput(input), inputRaw: input }) : {}),
             executing,
             status: payload.status,
             arguments: 'arguments' in payload ? payload.arguments : undefined,

--- a/cmd/web-chat/web/src/ws/timelineEvents.ts
+++ b/cmd/web-chat/web/src/ws/timelineEvents.ts
@@ -14,8 +14,8 @@ type TimelineMutation = {
   status?: string;
 };
 
-function visibleText(payload: { content?: string; text?: string; chunk?: string }): string {
-  return payload.content || payload.text || payload.chunk || '';
+function visibleText(payload: { content?: string; text?: string }): string {
+  return payload.content || payload.text || '';
 }
 
 function definedProps(props: Record<string, unknown>): Record<string, unknown> {
@@ -112,7 +112,7 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
         upsert: undefined,
       };
     }
-    case 'ChatTextDelta': {
+    case 'ChatTextPatch': {
       const payload = event.payload;
       const messageId = payload.messageId;
       if (!messageId) return null;
@@ -120,9 +120,9 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
         upsert: messageEntity(messageId, {
           role: payload.role || 'assistant',
           prompt: payload.prompt,
-          content: visibleText(payload),
+          contentPatch: visibleText(payload),
           status: payload.status || 'streaming',
-          streaming: true,
+          streaming: !payload.final,
           parentMessageId: parentMessageId(messageId, ':text:'),
           final: false,
           ...correlationProps(payload.correlation),
@@ -160,16 +160,16 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
       if (!messageId) return null;
       return { status: 'streaming' };
     }
-    case 'ChatReasoningDelta': {
+    case 'ChatReasoningPatch': {
       const payload = event.payload;
       const messageId = payload.messageId;
       if (!messageId) return null;
       return {
         upsert: messageEntity(messageId, {
           role: 'thinking',
-          content: visibleText(payload),
+          contentPatch: visibleText(payload),
           status: payload.status || 'streaming',
-          streaming: payload.streaming !== false,
+          streaming: !payload.final,
           parentMessageId: payload.parentMessageId,
           source: payload.source,
           ...correlationProps(payload.correlation),
@@ -238,14 +238,15 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
       return { deleteId: agentModePreviewEntityId(messageId) };
     }
     case 'ChatToolCallStarted':
-    case 'ChatToolCallArgumentsDelta':
+    case 'ChatToolArgumentsPatch':
     case 'ChatToolCallRequested':
     case 'ChatToolExecutionStarted':
     case 'ChatToolCallFinished': {
       const payload = event.payload;
       if (!payload.toolCallId) return null;
-      const hasInput = 'input' in payload && payload.input !== '';
-      const input = hasInput ? payload.input : '';
+      const isPatch = event.name === 'ChatToolArgumentsPatch';
+      const hasInput = isPatch ? 'arguments' in payload && payload.arguments !== '' : 'input' in payload && payload.input !== '';
+      const input = hasInput ? (isPatch && 'arguments' in payload ? payload.arguments : 'input' in payload ? payload.input : '') : '';
       const executing = 'executing' in payload ? payload.executing : false;
       return {
         upsert: toolCallEntity(
@@ -255,10 +256,10 @@ export function timelineMutationFromUIEvent(frame: CanonicalFrame): TimelineMuta
             toolCallId: payload.toolCallId,
             name: payload.toolName,
             toolName: payload.toolName,
-            ...(hasInput ? { input: parseToolInput(input), inputRaw: input } : {}),
+            ...(hasInput ? (isPatch ? { inputRawPatch: input } : { input: parseToolInput(input), inputRaw: input }) : {}),
             executing,
             status: payload.status,
-            argumentsDelta: 'argumentsDelta' in payload ? payload.argumentsDelta : undefined,
+            arguments: 'arguments' in payload ? payload.arguments : undefined,
             ...correlationProps(payload.correlation),
             done: event.name === 'ChatToolCallFinished' || payload.status === 'completed',
           }),

--- a/cmd/web-chat/web/src/ws/timelineProtocol.test.ts
+++ b/cmd/web-chat/web/src/ws/timelineProtocol.test.ts
@@ -153,7 +153,98 @@ describe('frontend timeline protocol matrix', () => {
     expect(entity?.props.parentMessageId).toBe('chat-msg-1');
   });
 
-  it('FRONTEND-05 missing tool result name does not persist display fallback as canonical state', () => {
+  it('FRONTEND-05 non-append text patches replace existing live content', () => {
+    const state = applyFrames([
+      {
+        name: 'ChatTextPatch',
+        payload: {
+          messageId: 'chat-msg-1:text:1',
+          role: 'assistant',
+          text: 'old ',
+          mode: 'CHAT_STREAM_PATCH_MODE_APPEND',
+          status: 'streaming',
+        },
+      },
+      {
+        name: 'ChatTextPatch',
+        payload: {
+          messageId: 'chat-msg-1:text:1',
+          role: 'assistant',
+          text: 'replacement',
+          mode: 'CHAT_STREAM_PATCH_MODE_REPLACE',
+          status: 'streaming',
+        },
+      },
+    ]);
+
+    const entity = state.byId['chat-msg-1:text:1'];
+    expect(entity?.kind).toBe('message');
+    expect(entity?.props.content).toBe('replacement');
+    expect(entity?.props.contentPatch).toBeUndefined();
+    expect(entity?.props.patchMode).toBeUndefined();
+  });
+
+  it('FRONTEND-06 non-append reasoning patches replace existing live content', () => {
+    const state = applyFrames([
+      {
+        name: 'ChatReasoningPatch',
+        payload: {
+          messageId: 'chat-msg-1:thinking:1',
+          parentMessageId: 'chat-msg-1',
+          text: 'partial reasoning',
+          mode: 'CHAT_STREAM_PATCH_MODE_APPEND',
+          status: 'streaming',
+        },
+      },
+      {
+        name: 'ChatReasoningPatch',
+        payload: {
+          messageId: 'chat-msg-1:thinking:1',
+          parentMessageId: 'chat-msg-1',
+          text: 'snapshot reasoning',
+          mode: 'CHAT_STREAM_PATCH_MODE_SNAPSHOT',
+          status: 'streaming',
+        },
+      },
+    ]);
+
+    const entity = state.byId['chat-msg-1:thinking:1'];
+    expect(entity?.kind).toBe('message');
+    expect(entity?.props.role).toBe('thinking');
+    expect(entity?.props.content).toBe('snapshot reasoning');
+  });
+
+  it('FRONTEND-07 non-append tool argument patches replace existing raw input', () => {
+    const state = applyFrames([
+      {
+        name: 'ChatToolCallRequested',
+        payload: {
+          messageId: 'chat-msg-1',
+          toolCallId: 'call_1',
+          toolName: 'sql_query',
+          input: '{"sql":"SELECT old"}',
+          status: 'pending',
+        },
+      },
+      {
+        name: 'ChatToolArgumentsPatch',
+        payload: {
+          messageId: 'chat-msg-1',
+          toolCallId: 'call_1',
+          toolName: 'sql_query',
+          arguments: '{"sql":"SELECT new"}',
+          mode: 'CHAT_STREAM_PATCH_MODE_REPLACE',
+          status: 'pending',
+        },
+      },
+    ]);
+
+    const entity = state.byId.call_1;
+    expect(entity?.props.inputRaw).toBe('{"sql":"SELECT new"}');
+    expect(entity?.props.input).toEqual({ sql: 'SELECT new' });
+  });
+
+  it('FRONTEND-08 missing tool result name does not persist display fallback as canonical state', () => {
     const mutation = timelineMutationFromUIEvent({
       name: 'ChatToolResultReady',
       payload: {

--- a/cmd/web-chat/web/src/ws/timelineProtocol.test.ts
+++ b/cmd/web-chat/web/src/ws/timelineProtocol.test.ts
@@ -85,7 +85,7 @@ describe('frontend timeline protocol matrix', () => {
 
     const state = applyFrames([
       {
-        name: 'ChatTextDelta',
+        name: 'ChatTextPatch',
         payload: {
           messageId: 'chat-msg-1:text:1',
           role: 'assistant',
@@ -122,7 +122,7 @@ describe('frontend timeline protocol matrix', () => {
 
     const state = applyFrames([
       {
-        name: 'ChatReasoningDelta',
+        name: 'ChatReasoningPatch',
         payload: {
           messageId: 'chat-msg-1:thinking:1',
           parentMessageId: 'chat-msg-1',

--- a/cmd/web-chat/web/src/ws/wsManager.test.ts
+++ b/cmd/web-chat/web/src/ws/wsManager.test.ts
@@ -112,9 +112,9 @@ describe('timelineMutationFromUIEvent', () => {
     expect(mutation).toEqual({ status: 'streaming' });
   });
 
-  it('creates a thinking message mutation for ChatReasoningDelta', () => {
+  it('creates a thinking message mutation for ChatReasoningPatch', () => {
     const mutation = timelineMutationFromUIEvent({
-      name: 'ChatReasoningDelta',
+      name: 'ChatReasoningPatch',
       payload: {
         messageId: 'chat-msg-2:thinking:1',
         content: 'draft plan',
@@ -188,9 +188,9 @@ describe('timelineMutationFromUIEvent', () => {
 
   it('preserves typed reasoning provider IDs and optional zero indexes', () => {
     const event = decodeKnownUIEvent({
-      name: 'ChatReasoningDelta',
+      name: 'ChatReasoningPatch',
       payload: {
-        '@type': 'type.googleapis.com/pinocchio.chatapp.v1.ChatReasoningDelta',
+        '@type': 'type.googleapis.com/pinocchio.chatapp.v1.ChatReasoningPatch',
         messageId: 'chat-msg-2:thinking:1',
         parentMessageId: 'chat-msg-2',
         chunk: 'plan',
@@ -203,8 +203,8 @@ describe('timelineMutationFromUIEvent', () => {
       },
     });
 
-    expect(event?.name).toBe('ChatReasoningDelta');
-    if (event?.name !== 'ChatReasoningDelta') throw new Error('expected typed reasoning event');
+    expect(event?.name).toBe('ChatReasoningPatch');
+    if (event?.name !== 'ChatReasoningPatch') throw new Error('expected typed reasoning event');
 
     const mutation = timelineMutationFromUIEvent({ name: event.name, payload: event.payload });
     expect(mutation?.upsert?.props.segmentId).toBe('reasoning-segment-1');

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/bobatea v0.1.5
 	github.com/go-go-golems/clay v0.4.9
-	github.com/go-go-golems/geppetto v0.11.27
-	github.com/go-go-golems/glazed v1.2.13
+	github.com/go-go-golems/geppetto v0.11.28
+	github.com/go-go-golems/glazed v1.2.14
 	github.com/go-go-golems/go-go-goja v0.4.16
 	github.com/go-go-golems/sessionstream v0.0.5
 	github.com/go-go-golems/uhoh v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -195,10 +195,10 @@ github.com/go-go-golems/bobatea v0.1.5 h1:WjY9dxJcTy+iGOoE9ROriSt6+m7j1Fedp2lUGN
 github.com/go-go-golems/bobatea v0.1.5/go.mod h1:FB1zWnEyIUOBDwtTXN7qRSEA8C7lxZ5KbowTUoHaa0g=
 github.com/go-go-golems/clay v0.4.9 h1:AEYlOOCUnjhQtDkvOLsr7MT1NY1bISPEm0bUqgbEixo=
 github.com/go-go-golems/clay v0.4.9/go.mod h1:xvi5Ii4B4GkuKAHIfEWKbhQ6yVCNXmDRsmQHsyklJpw=
-github.com/go-go-golems/geppetto v0.11.27 h1:wTZQcVDbnAJc53pXM5xjbYqkk7Q+Or8rmDeVh+aah2Y=
-github.com/go-go-golems/geppetto v0.11.27/go.mod h1:CF9CKLHG9oO+SeQlLvDRv1d/mE3arGUtlONX9j5D8oI=
-github.com/go-go-golems/glazed v1.2.13 h1:lHi39tMCqa9KcY3m24ZKxOSeNzQrSxXUXNNIOQb+OV4=
-github.com/go-go-golems/glazed v1.2.13/go.mod h1:f2d+NFZdM8ZatdP8B0dfUyhx3vap7VR6BBLbZEQVokk=
+github.com/go-go-golems/geppetto v0.11.28 h1:bUzUsXHOY23V944Q5p3LFL5wlRqpLEHEGfxIC/KV4Zo=
+github.com/go-go-golems/geppetto v0.11.28/go.mod h1:CF9CKLHG9oO+SeQlLvDRv1d/mE3arGUtlONX9j5D8oI=
+github.com/go-go-golems/glazed v1.2.14 h1:UL56KhYMIVVgqv7n0IWPybE3oYPMk8XRnk/OXBCsiTs=
+github.com/go-go-golems/glazed v1.2.14/go.mod h1:f2d+NFZdM8ZatdP8B0dfUyhx3vap7VR6BBLbZEQVokk=
 github.com/go-go-golems/go-go-goja v0.4.16 h1:IveXWTtNZKhCbWyhvs9rsStGnlM+O1Cz1K0xMrnkB3k=
 github.com/go-go-golems/go-go-goja v0.4.16/go.mod h1:RbqZWjsZh4Q3Qv9SwQgbkKzRdSqGHzYxbr6naky2y3M=
 github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=

--- a/pkg/chatapp/chat.go
+++ b/pkg/chatapp/chat.go
@@ -25,13 +25,13 @@ const (
 	EventChatProviderCallMetadataUpdated = "ChatProviderCallMetadataUpdated"
 	EventChatProviderCallFinished        = "ChatProviderCallFinished"
 	EventChatTextSegmentStarted          = "ChatTextSegmentStarted"
-	EventChatTextDelta                   = "ChatTextDelta"
+	EventChatTextPatch                   = "ChatTextPatch"
 	EventChatTextSegmentFinished         = "ChatTextSegmentFinished"
 	EventChatReasoningSegmentStarted     = "ChatReasoningSegmentStarted"
-	EventChatReasoningDelta              = "ChatReasoningDelta"
+	EventChatReasoningPatch              = "ChatReasoningPatch"
 	EventChatReasoningSegmentFinished    = "ChatReasoningSegmentFinished"
 	EventChatToolCallStarted             = "ChatToolCallStarted"
-	EventChatToolCallArgumentsDelta      = "ChatToolCallArgumentsDelta"
+	EventChatToolArgumentsPatch          = "ChatToolArgumentsPatch"
 	EventChatToolCallRequested           = "ChatToolCallRequested"
 	EventChatToolExecutionStarted        = "ChatToolExecutionStarted"
 	EventChatToolResultReady             = "ChatToolResultReady"
@@ -108,7 +108,7 @@ func RegisterSchemas(reg *sessionstream.SchemaRegistry, features ...ChatPlugin) 
 		reg.RegisterEvent(EventChatProviderCallMetadataUpdated, &chatappv1.ChatProviderCallMetadataUpdated{}),
 		reg.RegisterEvent(EventChatProviderCallFinished, &chatappv1.ChatProviderCallFinished{}),
 		reg.RegisterEvent(EventChatTextSegmentStarted, &chatappv1.ChatTextSegmentStarted{}),
-		reg.RegisterEvent(EventChatTextDelta, &chatappv1.ChatTextDelta{}),
+		reg.RegisterEvent(EventChatTextPatch, &chatappv1.ChatTextPatch{}),
 		reg.RegisterEvent(EventChatTextSegmentFinished, &chatappv1.ChatTextSegmentFinished{}),
 		reg.RegisterUIEvent(EventUserMessageAccepted, &chatappv1.ChatUserMessageAccepted{}),
 		reg.RegisterUIEvent(EventChatRunStarted, &chatappv1.ChatRunStarted{}),
@@ -119,7 +119,7 @@ func RegisterSchemas(reg *sessionstream.SchemaRegistry, features ...ChatPlugin) 
 		reg.RegisterUIEvent(EventChatProviderCallMetadataUpdated, &chatappv1.ChatProviderCallMetadataUpdated{}),
 		reg.RegisterUIEvent(EventChatProviderCallFinished, &chatappv1.ChatProviderCallFinished{}),
 		reg.RegisterUIEvent(EventChatTextSegmentStarted, &chatappv1.ChatTextSegmentStarted{}),
-		reg.RegisterUIEvent(EventChatTextDelta, &chatappv1.ChatTextDelta{}),
+		reg.RegisterUIEvent(EventChatTextPatch, &chatappv1.ChatTextPatch{}),
 		reg.RegisterUIEvent(EventChatTextSegmentFinished, &chatappv1.ChatTextSegmentFinished{}),
 		reg.RegisterTimelineEntity(TimelineEntityChatMessage, &chatappv1.ChatMessageEntity{}),
 	} {

--- a/pkg/chatapp/demo.go
+++ b/pkg/chatapp/demo.go
@@ -21,7 +21,7 @@ func (e *Engine) runDemoInference(ctx context.Context, sid sessionstream.Session
 	if err := e.publish(publishContext(ctx), sid, pub, EventChatTextSegmentStarted, &chatappv1.ChatTextSegmentStarted{MessageId: textMessageID, Role: "assistant", Prompt: prompt, Status: "streaming", Streaming: true, Correlation: corr}); err != nil {
 		return
 	}
-	for _, chunk := range chunks {
+	for i, chunk := range chunks {
 		select {
 		case <-ctx.Done():
 			_ = e.publish(publishContext(ctx), sid, pub, EventChatTextSegmentFinished, &chatappv1.ChatTextSegmentFinished{MessageId: textMessageID, Role: "assistant", Prompt: prompt, Text: accumulated, Content: accumulated, Status: "stopped", Streaming: false, Final: true, FinishReason: "stopped", Correlation: corr})
@@ -30,7 +30,7 @@ func (e *Engine) runDemoInference(ctx context.Context, sid sessionstream.Session
 		case <-time.After(e.chunkDelay):
 		}
 		accumulated += chunk
-		if err := e.publish(publishContext(ctx), sid, pub, EventChatTextDelta, &chatappv1.ChatTextDelta{MessageId: textMessageID, Role: "assistant", Prompt: prompt, Chunk: chunk, Text: accumulated, Content: accumulated, Status: "streaming", Streaming: true, Correlation: corr}); err != nil {
+		if err := e.publish(publishContext(ctx), sid, pub, EventChatTextPatch, &chatappv1.ChatTextPatch{MessageId: textMessageID, Role: "assistant", Prompt: prompt, StreamId: textMessageID, Sequence: uint64(i + 1), Offset: uint64(len(accumulated) - len(chunk)), Text: chunk, Mode: chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, Status: "streaming", Correlation: corr}); err != nil {
 			return
 		}
 	}

--- a/pkg/chatapp/demo.go
+++ b/pkg/chatapp/demo.go
@@ -30,7 +30,7 @@ func (e *Engine) runDemoInference(ctx context.Context, sid sessionstream.Session
 		case <-time.After(e.chunkDelay):
 		}
 		accumulated += chunk
-		if err := e.publish(publishContext(ctx), sid, pub, EventChatTextPatch, &chatappv1.ChatTextPatch{MessageId: textMessageID, Role: "assistant", Prompt: prompt, StreamId: textMessageID, Sequence: uint64(i + 1), Offset: uint64(len(accumulated) - len(chunk)), Text: chunk, Mode: chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, Status: "streaming", Correlation: corr}); err != nil {
+		if err := e.publish(publishContext(ctx), sid, pub, EventChatTextPatch, &chatappv1.ChatTextPatch{MessageId: textMessageID, Role: "assistant", Prompt: prompt, StreamId: textMessageID, Sequence: Uint64FromInt(i + 1), Offset: PatchOffset(accumulated, chunk), Text: chunk, Mode: chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, Status: "streaming", Correlation: corr}); err != nil {
 			return
 		}
 	}

--- a/pkg/chatapp/pb/proto/pinocchio/chatapp/v1/chat.pb.go
+++ b/pkg/chatapp/pb/proto/pinocchio/chatapp/v1/chat.pb.go
@@ -21,6 +21,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ChatStreamPatchMode int32
+
+const (
+	ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_UNSPECIFIED ChatStreamPatchMode = 0
+	ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND      ChatStreamPatchMode = 1
+	ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_SNAPSHOT    ChatStreamPatchMode = 2
+	ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_REPLACE     ChatStreamPatchMode = 3
+)
+
+// Enum value maps for ChatStreamPatchMode.
+var (
+	ChatStreamPatchMode_name = map[int32]string{
+		0: "CHAT_STREAM_PATCH_MODE_UNSPECIFIED",
+		1: "CHAT_STREAM_PATCH_MODE_APPEND",
+		2: "CHAT_STREAM_PATCH_MODE_SNAPSHOT",
+		3: "CHAT_STREAM_PATCH_MODE_REPLACE",
+	}
+	ChatStreamPatchMode_value = map[string]int32{
+		"CHAT_STREAM_PATCH_MODE_UNSPECIFIED": 0,
+		"CHAT_STREAM_PATCH_MODE_APPEND":      1,
+		"CHAT_STREAM_PATCH_MODE_SNAPSHOT":    2,
+		"CHAT_STREAM_PATCH_MODE_REPLACE":     3,
+	}
+)
+
+func (x ChatStreamPatchMode) Enum() *ChatStreamPatchMode {
+	p := new(ChatStreamPatchMode)
+	*p = x
+	return p
+}
+
+func (x ChatStreamPatchMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ChatStreamPatchMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_pinocchio_chatapp_v1_chat_proto_enumTypes[0].Descriptor()
+}
+
+func (ChatStreamPatchMode) Type() protoreflect.EnumType {
+	return &file_proto_pinocchio_chatapp_v1_chat_proto_enumTypes[0]
+}
+
+func (x ChatStreamPatchMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ChatStreamPatchMode.Descriptor instead.
+func (ChatStreamPatchMode) EnumDescriptor() ([]byte, []int) {
+	return file_proto_pinocchio_chatapp_v1_chat_proto_rawDescGZIP(), []int{0}
+}
+
 type StartInferenceCommand struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Prompt         string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
@@ -821,35 +873,38 @@ func (x *ChatTextSegmentStarted) GetCorrelation() *CorrelationInfo {
 	return nil
 }
 
-type ChatTextDelta struct {
+type ChatTextPatch struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	MessageId     string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
 	Role          string                 `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
-	Prompt        string                 `protobuf:"bytes,3,opt,name=prompt,proto3" json:"prompt,omitempty"`
-	Chunk         string                 `protobuf:"bytes,4,opt,name=chunk,proto3" json:"chunk,omitempty"`
-	Text          string                 `protobuf:"bytes,5,opt,name=text,proto3" json:"text,omitempty"`
-	Content       string                 `protobuf:"bytes,6,opt,name=content,proto3" json:"content,omitempty"`
-	Status        string                 `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
-	Streaming     bool                   `protobuf:"varint,8,opt,name=streaming,proto3" json:"streaming,omitempty"`
-	Correlation   *CorrelationInfo       `protobuf:"bytes,9,opt,name=correlation,proto3" json:"correlation,omitempty"`
+	StreamId      string                 `protobuf:"bytes,3,opt,name=stream_id,json=streamId,proto3" json:"stream_id,omitempty"`
+	Sequence      uint64                 `protobuf:"varint,4,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	Offset        uint64                 `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
+	Text          string                 `protobuf:"bytes,6,opt,name=text,proto3" json:"text,omitempty"`
+	Mode          ChatStreamPatchMode    `protobuf:"varint,7,opt,name=mode,proto3,enum=pinocchio.chatapp.v1.ChatStreamPatchMode" json:"mode,omitempty"`
+	Status        string                 `protobuf:"bytes,8,opt,name=status,proto3" json:"status,omitempty"`
+	Final         bool                   `protobuf:"varint,9,opt,name=final,proto3" json:"final,omitempty"`
+	FinishReason  string                 `protobuf:"bytes,10,opt,name=finish_reason,json=finishReason,proto3" json:"finish_reason,omitempty"`
+	Prompt        string                 `protobuf:"bytes,11,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	Correlation   *CorrelationInfo       `protobuf:"bytes,12,opt,name=correlation,proto3" json:"correlation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ChatTextDelta) Reset() {
-	*x = ChatTextDelta{}
+func (x *ChatTextPatch) Reset() {
+	*x = ChatTextPatch{}
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ChatTextDelta) String() string {
+func (x *ChatTextPatch) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ChatTextDelta) ProtoMessage() {}
+func (*ChatTextPatch) ProtoMessage() {}
 
-func (x *ChatTextDelta) ProtoReflect() protoreflect.Message {
+func (x *ChatTextPatch) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -861,68 +916,89 @@ func (x *ChatTextDelta) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ChatTextDelta.ProtoReflect.Descriptor instead.
-func (*ChatTextDelta) Descriptor() ([]byte, []int) {
+// Deprecated: Use ChatTextPatch.ProtoReflect.Descriptor instead.
+func (*ChatTextPatch) Descriptor() ([]byte, []int) {
 	return file_proto_pinocchio_chatapp_v1_chat_proto_rawDescGZIP(), []int{12}
 }
 
-func (x *ChatTextDelta) GetMessageId() string {
+func (x *ChatTextPatch) GetMessageId() string {
 	if x != nil {
 		return x.MessageId
 	}
 	return ""
 }
 
-func (x *ChatTextDelta) GetRole() string {
+func (x *ChatTextPatch) GetRole() string {
 	if x != nil {
 		return x.Role
 	}
 	return ""
 }
 
-func (x *ChatTextDelta) GetPrompt() string {
+func (x *ChatTextPatch) GetStreamId() string {
 	if x != nil {
-		return x.Prompt
+		return x.StreamId
 	}
 	return ""
 }
 
-func (x *ChatTextDelta) GetChunk() string {
+func (x *ChatTextPatch) GetSequence() uint64 {
 	if x != nil {
-		return x.Chunk
+		return x.Sequence
 	}
-	return ""
+	return 0
 }
 
-func (x *ChatTextDelta) GetText() string {
+func (x *ChatTextPatch) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ChatTextPatch) GetText() string {
 	if x != nil {
 		return x.Text
 	}
 	return ""
 }
 
-func (x *ChatTextDelta) GetContent() string {
+func (x *ChatTextPatch) GetMode() ChatStreamPatchMode {
 	if x != nil {
-		return x.Content
+		return x.Mode
 	}
-	return ""
+	return ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_UNSPECIFIED
 }
 
-func (x *ChatTextDelta) GetStatus() string {
+func (x *ChatTextPatch) GetStatus() string {
 	if x != nil {
 		return x.Status
 	}
 	return ""
 }
 
-func (x *ChatTextDelta) GetStreaming() bool {
+func (x *ChatTextPatch) GetFinal() bool {
 	if x != nil {
-		return x.Streaming
+		return x.Final
 	}
 	return false
 }
 
-func (x *ChatTextDelta) GetCorrelation() *CorrelationInfo {
+func (x *ChatTextPatch) GetFinishReason() string {
+	if x != nil {
+		return x.FinishReason
+	}
+	return ""
+}
+
+func (x *ChatTextPatch) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+func (x *ChatTextPatch) GetCorrelation() *CorrelationInfo {
 	if x != nil {
 		return x.Correlation
 	}
@@ -1137,36 +1213,39 @@ func (x *ChatReasoningSegmentStarted) GetCorrelation() *CorrelationInfo {
 	return nil
 }
 
-type ChatReasoningDelta struct {
+type ChatReasoningPatch struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	MessageId       string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
 	ParentMessageId string                 `protobuf:"bytes,2,opt,name=parent_message_id,json=parentMessageId,proto3" json:"parent_message_id,omitempty"`
 	Role            string                 `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
-	Chunk           string                 `protobuf:"bytes,4,opt,name=chunk,proto3" json:"chunk,omitempty"`
-	Text            string                 `protobuf:"bytes,5,opt,name=text,proto3" json:"text,omitempty"`
-	Content         string                 `protobuf:"bytes,6,opt,name=content,proto3" json:"content,omitempty"`
-	Status          string                 `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
-	Streaming       bool                   `protobuf:"varint,8,opt,name=streaming,proto3" json:"streaming,omitempty"`
-	Source          string                 `protobuf:"bytes,9,opt,name=source,proto3" json:"source,omitempty"`
-	Correlation     *CorrelationInfo       `protobuf:"bytes,10,opt,name=correlation,proto3" json:"correlation,omitempty"`
+	StreamId        string                 `protobuf:"bytes,4,opt,name=stream_id,json=streamId,proto3" json:"stream_id,omitempty"`
+	Sequence        uint64                 `protobuf:"varint,5,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	Offset          uint64                 `protobuf:"varint,6,opt,name=offset,proto3" json:"offset,omitempty"`
+	Text            string                 `protobuf:"bytes,7,opt,name=text,proto3" json:"text,omitempty"`
+	Mode            ChatStreamPatchMode    `protobuf:"varint,8,opt,name=mode,proto3,enum=pinocchio.chatapp.v1.ChatStreamPatchMode" json:"mode,omitempty"`
+	Status          string                 `protobuf:"bytes,9,opt,name=status,proto3" json:"status,omitempty"`
+	Final           bool                   `protobuf:"varint,10,opt,name=final,proto3" json:"final,omitempty"`
+	Source          string                 `protobuf:"bytes,11,opt,name=source,proto3" json:"source,omitempty"`
+	FinishReason    string                 `protobuf:"bytes,12,opt,name=finish_reason,json=finishReason,proto3" json:"finish_reason,omitempty"`
+	Correlation     *CorrelationInfo       `protobuf:"bytes,13,opt,name=correlation,proto3" json:"correlation,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
 
-func (x *ChatReasoningDelta) Reset() {
-	*x = ChatReasoningDelta{}
+func (x *ChatReasoningPatch) Reset() {
+	*x = ChatReasoningPatch{}
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ChatReasoningDelta) String() string {
+func (x *ChatReasoningPatch) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ChatReasoningDelta) ProtoMessage() {}
+func (*ChatReasoningPatch) ProtoMessage() {}
 
-func (x *ChatReasoningDelta) ProtoReflect() protoreflect.Message {
+func (x *ChatReasoningPatch) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1178,75 +1257,96 @@ func (x *ChatReasoningDelta) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ChatReasoningDelta.ProtoReflect.Descriptor instead.
-func (*ChatReasoningDelta) Descriptor() ([]byte, []int) {
+// Deprecated: Use ChatReasoningPatch.ProtoReflect.Descriptor instead.
+func (*ChatReasoningPatch) Descriptor() ([]byte, []int) {
 	return file_proto_pinocchio_chatapp_v1_chat_proto_rawDescGZIP(), []int{15}
 }
 
-func (x *ChatReasoningDelta) GetMessageId() string {
+func (x *ChatReasoningPatch) GetMessageId() string {
 	if x != nil {
 		return x.MessageId
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetParentMessageId() string {
+func (x *ChatReasoningPatch) GetParentMessageId() string {
 	if x != nil {
 		return x.ParentMessageId
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetRole() string {
+func (x *ChatReasoningPatch) GetRole() string {
 	if x != nil {
 		return x.Role
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetChunk() string {
+func (x *ChatReasoningPatch) GetStreamId() string {
 	if x != nil {
-		return x.Chunk
+		return x.StreamId
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetText() string {
+func (x *ChatReasoningPatch) GetSequence() uint64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *ChatReasoningPatch) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ChatReasoningPatch) GetText() string {
 	if x != nil {
 		return x.Text
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetContent() string {
+func (x *ChatReasoningPatch) GetMode() ChatStreamPatchMode {
 	if x != nil {
-		return x.Content
+		return x.Mode
 	}
-	return ""
+	return ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_UNSPECIFIED
 }
 
-func (x *ChatReasoningDelta) GetStatus() string {
+func (x *ChatReasoningPatch) GetStatus() string {
 	if x != nil {
 		return x.Status
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetStreaming() bool {
+func (x *ChatReasoningPatch) GetFinal() bool {
 	if x != nil {
-		return x.Streaming
+		return x.Final
 	}
 	return false
 }
 
-func (x *ChatReasoningDelta) GetSource() string {
+func (x *ChatReasoningPatch) GetSource() string {
 	if x != nil {
 		return x.Source
 	}
 	return ""
 }
 
-func (x *ChatReasoningDelta) GetCorrelation() *CorrelationInfo {
+func (x *ChatReasoningPatch) GetFinishReason() string {
+	if x != nil {
+		return x.FinishReason
+	}
+	return ""
+}
+
+func (x *ChatReasoningPatch) GetCorrelation() *CorrelationInfo {
 	if x != nil {
 		return x.Correlation
 	}
@@ -1461,33 +1561,37 @@ func (x *ChatToolCallStarted) GetCorrelation() *CorrelationInfo {
 	return nil
 }
 
-type ChatToolCallArgumentsDelta struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	MessageId      string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
-	ToolCallId     string                 `protobuf:"bytes,2,opt,name=tool_call_id,json=toolCallId,proto3" json:"tool_call_id,omitempty"`
-	ToolName       string                 `protobuf:"bytes,3,opt,name=tool_name,json=toolName,proto3" json:"tool_name,omitempty"`
-	ArgumentsDelta string                 `protobuf:"bytes,4,opt,name=arguments_delta,json=argumentsDelta,proto3" json:"arguments_delta,omitempty"`
-	Input          string                 `protobuf:"bytes,5,opt,name=input,proto3" json:"input,omitempty"`
-	Status         string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
-	Correlation    *CorrelationInfo       `protobuf:"bytes,7,opt,name=correlation,proto3" json:"correlation,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+type ChatToolArgumentsPatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	MessageId     string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
+	ToolCallId    string                 `protobuf:"bytes,2,opt,name=tool_call_id,json=toolCallId,proto3" json:"tool_call_id,omitempty"`
+	ToolName      string                 `protobuf:"bytes,3,opt,name=tool_name,json=toolName,proto3" json:"tool_name,omitempty"`
+	StreamId      string                 `protobuf:"bytes,4,opt,name=stream_id,json=streamId,proto3" json:"stream_id,omitempty"`
+	Sequence      uint64                 `protobuf:"varint,5,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	Offset        uint64                 `protobuf:"varint,6,opt,name=offset,proto3" json:"offset,omitempty"`
+	Arguments     string                 `protobuf:"bytes,7,opt,name=arguments,proto3" json:"arguments,omitempty"`
+	Mode          ChatStreamPatchMode    `protobuf:"varint,8,opt,name=mode,proto3,enum=pinocchio.chatapp.v1.ChatStreamPatchMode" json:"mode,omitempty"`
+	Status        string                 `protobuf:"bytes,9,opt,name=status,proto3" json:"status,omitempty"`
+	Final         bool                   `protobuf:"varint,10,opt,name=final,proto3" json:"final,omitempty"`
+	Correlation   *CorrelationInfo       `protobuf:"bytes,11,opt,name=correlation,proto3" json:"correlation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ChatToolCallArgumentsDelta) Reset() {
-	*x = ChatToolCallArgumentsDelta{}
+func (x *ChatToolArgumentsPatch) Reset() {
+	*x = ChatToolArgumentsPatch{}
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ChatToolCallArgumentsDelta) String() string {
+func (x *ChatToolArgumentsPatch) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ChatToolCallArgumentsDelta) ProtoMessage() {}
+func (*ChatToolArgumentsPatch) ProtoMessage() {}
 
-func (x *ChatToolCallArgumentsDelta) ProtoReflect() protoreflect.Message {
+func (x *ChatToolArgumentsPatch) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1499,54 +1603,82 @@ func (x *ChatToolCallArgumentsDelta) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ChatToolCallArgumentsDelta.ProtoReflect.Descriptor instead.
-func (*ChatToolCallArgumentsDelta) Descriptor() ([]byte, []int) {
+// Deprecated: Use ChatToolArgumentsPatch.ProtoReflect.Descriptor instead.
+func (*ChatToolArgumentsPatch) Descriptor() ([]byte, []int) {
 	return file_proto_pinocchio_chatapp_v1_chat_proto_rawDescGZIP(), []int{18}
 }
 
-func (x *ChatToolCallArgumentsDelta) GetMessageId() string {
+func (x *ChatToolArgumentsPatch) GetMessageId() string {
 	if x != nil {
 		return x.MessageId
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetToolCallId() string {
+func (x *ChatToolArgumentsPatch) GetToolCallId() string {
 	if x != nil {
 		return x.ToolCallId
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetToolName() string {
+func (x *ChatToolArgumentsPatch) GetToolName() string {
 	if x != nil {
 		return x.ToolName
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetArgumentsDelta() string {
+func (x *ChatToolArgumentsPatch) GetStreamId() string {
 	if x != nil {
-		return x.ArgumentsDelta
+		return x.StreamId
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetInput() string {
+func (x *ChatToolArgumentsPatch) GetSequence() uint64 {
 	if x != nil {
-		return x.Input
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *ChatToolArgumentsPatch) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ChatToolArgumentsPatch) GetArguments() string {
+	if x != nil {
+		return x.Arguments
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetStatus() string {
+func (x *ChatToolArgumentsPatch) GetMode() ChatStreamPatchMode {
+	if x != nil {
+		return x.Mode
+	}
+	return ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_UNSPECIFIED
+}
+
+func (x *ChatToolArgumentsPatch) GetStatus() string {
 	if x != nil {
 		return x.Status
 	}
 	return ""
 }
 
-func (x *ChatToolCallArgumentsDelta) GetCorrelation() *CorrelationInfo {
+func (x *ChatToolArgumentsPatch) GetFinal() bool {
+	if x != nil {
+		return x.Final
+	}
+	return false
+}
+
+func (x *ChatToolArgumentsPatch) GetCorrelation() *CorrelationInfo {
 	if x != nil {
 		return x.Correlation
 	}
@@ -2662,18 +2794,22 @@ const file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc = "" +
 	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12\x16\n" +
 	"\x06status\x18\x04 \x01(\tR\x06status\x12\x1c\n" +
 	"\tstreaming\x18\x05 \x01(\bR\tstreaming\x12G\n" +
-	"\vcorrelation\x18\x06 \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x9d\x02\n" +
-	"\rChatTextDelta\x12\x1d\n" +
+	"\vcorrelation\x18\x06 \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x9a\x03\n" +
+	"\rChatTextPatch\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12\x12\n" +
-	"\x04role\x18\x02 \x01(\tR\x04role\x12\x16\n" +
-	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12\x14\n" +
-	"\x05chunk\x18\x04 \x01(\tR\x05chunk\x12\x12\n" +
-	"\x04text\x18\x05 \x01(\tR\x04text\x12\x18\n" +
-	"\acontent\x18\x06 \x01(\tR\acontent\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status\x12\x1c\n" +
-	"\tstreaming\x18\b \x01(\bR\tstreaming\x12G\n" +
-	"\vcorrelation\x18\t \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xcc\x02\n" +
+	"\x04role\x18\x02 \x01(\tR\x04role\x12\x1b\n" +
+	"\tstream_id\x18\x03 \x01(\tR\bstreamId\x12\x1a\n" +
+	"\bsequence\x18\x04 \x01(\x04R\bsequence\x12\x16\n" +
+	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x12\n" +
+	"\x04text\x18\x06 \x01(\tR\x04text\x12=\n" +
+	"\x04mode\x18\a \x01(\x0e2).pinocchio.chatapp.v1.ChatStreamPatchModeR\x04mode\x12\x16\n" +
+	"\x06status\x18\b \x01(\tR\x06status\x12\x14\n" +
+	"\x05final\x18\t \x01(\bR\x05final\x12#\n" +
+	"\rfinish_reason\x18\n" +
+	" \x01(\tR\ffinishReason\x12\x16\n" +
+	"\x06prompt\x18\v \x01(\tR\x06prompt\x12G\n" +
+	"\vcorrelation\x18\f \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xcc\x02\n" +
 	"\x17ChatTextSegmentFinished\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12\x12\n" +
@@ -2695,20 +2831,23 @@ const file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc = "" +
 	"\x06status\x18\x04 \x01(\tR\x06status\x12\x1c\n" +
 	"\tstreaming\x18\x05 \x01(\bR\tstreaming\x12\x16\n" +
 	"\x06source\x18\x06 \x01(\tR\x06source\x12G\n" +
-	"\vcorrelation\x18\a \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xce\x02\n" +
-	"\x12ChatReasoningDelta\x12\x1d\n" +
+	"\vcorrelation\x18\a \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xcb\x03\n" +
+	"\x12ChatReasoningPatch\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12*\n" +
 	"\x11parent_message_id\x18\x02 \x01(\tR\x0fparentMessageId\x12\x12\n" +
-	"\x04role\x18\x03 \x01(\tR\x04role\x12\x14\n" +
-	"\x05chunk\x18\x04 \x01(\tR\x05chunk\x12\x12\n" +
-	"\x04text\x18\x05 \x01(\tR\x04text\x12\x18\n" +
-	"\acontent\x18\x06 \x01(\tR\acontent\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status\x12\x1c\n" +
-	"\tstreaming\x18\b \x01(\bR\tstreaming\x12\x16\n" +
-	"\x06source\x18\t \x01(\tR\x06source\x12G\n" +
-	"\vcorrelation\x18\n" +
-	" \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xe7\x02\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\x12\x1b\n" +
+	"\tstream_id\x18\x04 \x01(\tR\bstreamId\x12\x1a\n" +
+	"\bsequence\x18\x05 \x01(\x04R\bsequence\x12\x16\n" +
+	"\x06offset\x18\x06 \x01(\x04R\x06offset\x12\x12\n" +
+	"\x04text\x18\a \x01(\tR\x04text\x12=\n" +
+	"\x04mode\x18\b \x01(\x0e2).pinocchio.chatapp.v1.ChatStreamPatchModeR\x04mode\x12\x16\n" +
+	"\x06status\x18\t \x01(\tR\x06status\x12\x14\n" +
+	"\x05final\x18\n" +
+	" \x01(\bR\x05final\x12\x16\n" +
+	"\x06source\x18\v \x01(\tR\x06source\x12#\n" +
+	"\rfinish_reason\x18\f \x01(\tR\ffinishReason\x12G\n" +
+	"\vcorrelation\x18\r \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\xe7\x02\n" +
 	"\x1cChatReasoningSegmentFinished\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12*\n" +
@@ -2731,17 +2870,22 @@ const file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc = "" +
 	"\x05input\x18\x04 \x01(\tR\x05input\x12\x1c\n" +
 	"\texecuting\x18\x05 \x01(\bR\texecuting\x12\x16\n" +
 	"\x06status\x18\x06 \x01(\tR\x06status\x12G\n" +
-	"\vcorrelation\x18\a \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x9a\x02\n" +
-	"\x1aChatToolCallArgumentsDelta\x12\x1d\n" +
+	"\vcorrelation\x18\a \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x9b\x03\n" +
+	"\x16ChatToolArgumentsPatch\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12 \n" +
 	"\ftool_call_id\x18\x02 \x01(\tR\n" +
 	"toolCallId\x12\x1b\n" +
-	"\ttool_name\x18\x03 \x01(\tR\btoolName\x12'\n" +
-	"\x0farguments_delta\x18\x04 \x01(\tR\x0eargumentsDelta\x12\x14\n" +
-	"\x05input\x18\x05 \x01(\tR\x05input\x12\x16\n" +
-	"\x06status\x18\x06 \x01(\tR\x06status\x12G\n" +
-	"\vcorrelation\x18\a \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x8a\x02\n" +
+	"\ttool_name\x18\x03 \x01(\tR\btoolName\x12\x1b\n" +
+	"\tstream_id\x18\x04 \x01(\tR\bstreamId\x12\x1a\n" +
+	"\bsequence\x18\x05 \x01(\x04R\bsequence\x12\x16\n" +
+	"\x06offset\x18\x06 \x01(\x04R\x06offset\x12\x1c\n" +
+	"\targuments\x18\a \x01(\tR\targuments\x12=\n" +
+	"\x04mode\x18\b \x01(\x0e2).pinocchio.chatapp.v1.ChatStreamPatchModeR\x04mode\x12\x16\n" +
+	"\x06status\x18\t \x01(\tR\x06status\x12\x14\n" +
+	"\x05final\x18\n" +
+	" \x01(\bR\x05final\x12G\n" +
+	"\vcorrelation\x18\v \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation\"\x8a\x02\n" +
 	"\x15ChatToolCallRequested\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12 \n" +
@@ -2848,7 +2992,12 @@ const file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc = "" +
 	"\ttool_name\x18\x03 \x01(\tR\btoolName\x12\x16\n" +
 	"\x06result\x18\x04 \x01(\tR\x06result\x12\x16\n" +
 	"\x06status\x18\x05 \x01(\tR\x06status\x12G\n" +
-	"\vcorrelation\x18\x06 \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelationBWZUgithub.com/go-go-golems/pinocchio/pkg/chatapp/pb/proto/pinocchio/chatapp/v1;chatappv1b\x06proto3"
+	"\vcorrelation\x18\x06 \x01(\v2%.pinocchio.chatapp.v1.CorrelationInfoR\vcorrelation*\xa9\x01\n" +
+	"\x13ChatStreamPatchMode\x12&\n" +
+	"\"CHAT_STREAM_PATCH_MODE_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dCHAT_STREAM_PATCH_MODE_APPEND\x10\x01\x12#\n" +
+	"\x1fCHAT_STREAM_PATCH_MODE_SNAPSHOT\x10\x02\x12\"\n" +
+	"\x1eCHAT_STREAM_PATCH_MODE_REPLACE\x10\x03BWZUgithub.com/go-go-golems/pinocchio/pkg/chatapp/pb/proto/pinocchio/chatapp/v1;chatappv1b\x06proto3"
 
 var (
 	file_proto_pinocchio_chatapp_v1_chat_proto_rawDescOnce sync.Once
@@ -2862,70 +3011,75 @@ func file_proto_pinocchio_chatapp_v1_chat_proto_rawDescGZIP() []byte {
 	return file_proto_pinocchio_chatapp_v1_chat_proto_rawDescData
 }
 
+var file_proto_pinocchio_chatapp_v1_chat_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_proto_pinocchio_chatapp_v1_chat_proto_goTypes = []any{
-	(*StartInferenceCommand)(nil),           // 0: pinocchio.chatapp.v1.StartInferenceCommand
-	(*StopInferenceCommand)(nil),            // 1: pinocchio.chatapp.v1.StopInferenceCommand
-	(*UsageInfo)(nil),                       // 2: pinocchio.chatapp.v1.UsageInfo
-	(*CorrelationInfo)(nil),                 // 3: pinocchio.chatapp.v1.CorrelationInfo
-	(*ChatRunStarted)(nil),                  // 4: pinocchio.chatapp.v1.ChatRunStarted
-	(*ChatRunFinished)(nil),                 // 5: pinocchio.chatapp.v1.ChatRunFinished
-	(*ChatRunStopped)(nil),                  // 6: pinocchio.chatapp.v1.ChatRunStopped
-	(*ChatRunFailed)(nil),                   // 7: pinocchio.chatapp.v1.ChatRunFailed
-	(*ChatProviderCallStarted)(nil),         // 8: pinocchio.chatapp.v1.ChatProviderCallStarted
-	(*ChatProviderCallMetadataUpdated)(nil), // 9: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated
-	(*ChatProviderCallFinished)(nil),        // 10: pinocchio.chatapp.v1.ChatProviderCallFinished
-	(*ChatTextSegmentStarted)(nil),          // 11: pinocchio.chatapp.v1.ChatTextSegmentStarted
-	(*ChatTextDelta)(nil),                   // 12: pinocchio.chatapp.v1.ChatTextDelta
-	(*ChatTextSegmentFinished)(nil),         // 13: pinocchio.chatapp.v1.ChatTextSegmentFinished
-	(*ChatReasoningSegmentStarted)(nil),     // 14: pinocchio.chatapp.v1.ChatReasoningSegmentStarted
-	(*ChatReasoningDelta)(nil),              // 15: pinocchio.chatapp.v1.ChatReasoningDelta
-	(*ChatReasoningSegmentFinished)(nil),    // 16: pinocchio.chatapp.v1.ChatReasoningSegmentFinished
-	(*ChatToolCallStarted)(nil),             // 17: pinocchio.chatapp.v1.ChatToolCallStarted
-	(*ChatToolCallArgumentsDelta)(nil),      // 18: pinocchio.chatapp.v1.ChatToolCallArgumentsDelta
-	(*ChatToolCallRequested)(nil),           // 19: pinocchio.chatapp.v1.ChatToolCallRequested
-	(*ChatToolExecutionStarted)(nil),        // 20: pinocchio.chatapp.v1.ChatToolExecutionStarted
-	(*ChatToolResultReady)(nil),             // 21: pinocchio.chatapp.v1.ChatToolResultReady
-	(*ChatToolCallFinished)(nil),            // 22: pinocchio.chatapp.v1.ChatToolCallFinished
-	(*ChatUserMessageAccepted)(nil),         // 23: pinocchio.chatapp.v1.ChatUserMessageAccepted
-	(*ChatMessageEntity)(nil),               // 24: pinocchio.chatapp.v1.ChatMessageEntity
-	(*AgentModePreviewUpdate)(nil),          // 25: pinocchio.chatapp.v1.AgentModePreviewUpdate
-	(*AgentModeCommittedUpdate)(nil),        // 26: pinocchio.chatapp.v1.AgentModeCommittedUpdate
-	(*AgentModePreviewCleared)(nil),         // 27: pinocchio.chatapp.v1.AgentModePreviewCleared
-	(*AgentModeEntity)(nil),                 // 28: pinocchio.chatapp.v1.AgentModeEntity
-	(*ToolCallEntity)(nil),                  // 29: pinocchio.chatapp.v1.ToolCallEntity
-	(*ToolResultEntity)(nil),                // 30: pinocchio.chatapp.v1.ToolResultEntity
+	(ChatStreamPatchMode)(0),                // 0: pinocchio.chatapp.v1.ChatStreamPatchMode
+	(*StartInferenceCommand)(nil),           // 1: pinocchio.chatapp.v1.StartInferenceCommand
+	(*StopInferenceCommand)(nil),            // 2: pinocchio.chatapp.v1.StopInferenceCommand
+	(*UsageInfo)(nil),                       // 3: pinocchio.chatapp.v1.UsageInfo
+	(*CorrelationInfo)(nil),                 // 4: pinocchio.chatapp.v1.CorrelationInfo
+	(*ChatRunStarted)(nil),                  // 5: pinocchio.chatapp.v1.ChatRunStarted
+	(*ChatRunFinished)(nil),                 // 6: pinocchio.chatapp.v1.ChatRunFinished
+	(*ChatRunStopped)(nil),                  // 7: pinocchio.chatapp.v1.ChatRunStopped
+	(*ChatRunFailed)(nil),                   // 8: pinocchio.chatapp.v1.ChatRunFailed
+	(*ChatProviderCallStarted)(nil),         // 9: pinocchio.chatapp.v1.ChatProviderCallStarted
+	(*ChatProviderCallMetadataUpdated)(nil), // 10: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated
+	(*ChatProviderCallFinished)(nil),        // 11: pinocchio.chatapp.v1.ChatProviderCallFinished
+	(*ChatTextSegmentStarted)(nil),          // 12: pinocchio.chatapp.v1.ChatTextSegmentStarted
+	(*ChatTextPatch)(nil),                   // 13: pinocchio.chatapp.v1.ChatTextPatch
+	(*ChatTextSegmentFinished)(nil),         // 14: pinocchio.chatapp.v1.ChatTextSegmentFinished
+	(*ChatReasoningSegmentStarted)(nil),     // 15: pinocchio.chatapp.v1.ChatReasoningSegmentStarted
+	(*ChatReasoningPatch)(nil),              // 16: pinocchio.chatapp.v1.ChatReasoningPatch
+	(*ChatReasoningSegmentFinished)(nil),    // 17: pinocchio.chatapp.v1.ChatReasoningSegmentFinished
+	(*ChatToolCallStarted)(nil),             // 18: pinocchio.chatapp.v1.ChatToolCallStarted
+	(*ChatToolArgumentsPatch)(nil),          // 19: pinocchio.chatapp.v1.ChatToolArgumentsPatch
+	(*ChatToolCallRequested)(nil),           // 20: pinocchio.chatapp.v1.ChatToolCallRequested
+	(*ChatToolExecutionStarted)(nil),        // 21: pinocchio.chatapp.v1.ChatToolExecutionStarted
+	(*ChatToolResultReady)(nil),             // 22: pinocchio.chatapp.v1.ChatToolResultReady
+	(*ChatToolCallFinished)(nil),            // 23: pinocchio.chatapp.v1.ChatToolCallFinished
+	(*ChatUserMessageAccepted)(nil),         // 24: pinocchio.chatapp.v1.ChatUserMessageAccepted
+	(*ChatMessageEntity)(nil),               // 25: pinocchio.chatapp.v1.ChatMessageEntity
+	(*AgentModePreviewUpdate)(nil),          // 26: pinocchio.chatapp.v1.AgentModePreviewUpdate
+	(*AgentModeCommittedUpdate)(nil),        // 27: pinocchio.chatapp.v1.AgentModeCommittedUpdate
+	(*AgentModePreviewCleared)(nil),         // 28: pinocchio.chatapp.v1.AgentModePreviewCleared
+	(*AgentModeEntity)(nil),                 // 29: pinocchio.chatapp.v1.AgentModeEntity
+	(*ToolCallEntity)(nil),                  // 30: pinocchio.chatapp.v1.ToolCallEntity
+	(*ToolResultEntity)(nil),                // 31: pinocchio.chatapp.v1.ToolResultEntity
 }
 var file_proto_pinocchio_chatapp_v1_chat_proto_depIdxs = []int32{
-	3,  // 0: pinocchio.chatapp.v1.ChatRunStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 1: pinocchio.chatapp.v1.ChatRunFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 2: pinocchio.chatapp.v1.ChatRunStopped.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 3: pinocchio.chatapp.v1.ChatRunFailed.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 4: pinocchio.chatapp.v1.ChatProviderCallStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	2,  // 5: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated.usage:type_name -> pinocchio.chatapp.v1.UsageInfo
-	3,  // 6: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	2,  // 7: pinocchio.chatapp.v1.ChatProviderCallFinished.usage:type_name -> pinocchio.chatapp.v1.UsageInfo
-	3,  // 8: pinocchio.chatapp.v1.ChatProviderCallFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 9: pinocchio.chatapp.v1.ChatTextSegmentStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 10: pinocchio.chatapp.v1.ChatTextDelta.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 11: pinocchio.chatapp.v1.ChatTextSegmentFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 12: pinocchio.chatapp.v1.ChatReasoningSegmentStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 13: pinocchio.chatapp.v1.ChatReasoningDelta.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 14: pinocchio.chatapp.v1.ChatReasoningSegmentFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 15: pinocchio.chatapp.v1.ChatToolCallStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 16: pinocchio.chatapp.v1.ChatToolCallArgumentsDelta.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 17: pinocchio.chatapp.v1.ChatToolCallRequested.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 18: pinocchio.chatapp.v1.ChatToolExecutionStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 19: pinocchio.chatapp.v1.ChatToolResultReady.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 20: pinocchio.chatapp.v1.ChatToolCallFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 21: pinocchio.chatapp.v1.ChatMessageEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 22: pinocchio.chatapp.v1.ToolCallEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	3,  // 23: pinocchio.chatapp.v1.ToolResultEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
-	24, // [24:24] is the sub-list for method output_type
-	24, // [24:24] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	4,  // 0: pinocchio.chatapp.v1.ChatRunStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 1: pinocchio.chatapp.v1.ChatRunFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 2: pinocchio.chatapp.v1.ChatRunStopped.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 3: pinocchio.chatapp.v1.ChatRunFailed.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 4: pinocchio.chatapp.v1.ChatProviderCallStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	3,  // 5: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated.usage:type_name -> pinocchio.chatapp.v1.UsageInfo
+	4,  // 6: pinocchio.chatapp.v1.ChatProviderCallMetadataUpdated.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	3,  // 7: pinocchio.chatapp.v1.ChatProviderCallFinished.usage:type_name -> pinocchio.chatapp.v1.UsageInfo
+	4,  // 8: pinocchio.chatapp.v1.ChatProviderCallFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 9: pinocchio.chatapp.v1.ChatTextSegmentStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	0,  // 10: pinocchio.chatapp.v1.ChatTextPatch.mode:type_name -> pinocchio.chatapp.v1.ChatStreamPatchMode
+	4,  // 11: pinocchio.chatapp.v1.ChatTextPatch.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 12: pinocchio.chatapp.v1.ChatTextSegmentFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 13: pinocchio.chatapp.v1.ChatReasoningSegmentStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	0,  // 14: pinocchio.chatapp.v1.ChatReasoningPatch.mode:type_name -> pinocchio.chatapp.v1.ChatStreamPatchMode
+	4,  // 15: pinocchio.chatapp.v1.ChatReasoningPatch.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 16: pinocchio.chatapp.v1.ChatReasoningSegmentFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 17: pinocchio.chatapp.v1.ChatToolCallStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	0,  // 18: pinocchio.chatapp.v1.ChatToolArgumentsPatch.mode:type_name -> pinocchio.chatapp.v1.ChatStreamPatchMode
+	4,  // 19: pinocchio.chatapp.v1.ChatToolArgumentsPatch.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 20: pinocchio.chatapp.v1.ChatToolCallRequested.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 21: pinocchio.chatapp.v1.ChatToolExecutionStarted.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 22: pinocchio.chatapp.v1.ChatToolResultReady.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 23: pinocchio.chatapp.v1.ChatToolCallFinished.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 24: pinocchio.chatapp.v1.ChatMessageEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 25: pinocchio.chatapp.v1.ToolCallEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	4,  // 26: pinocchio.chatapp.v1.ToolResultEntity.correlation:type_name -> pinocchio.chatapp.v1.CorrelationInfo
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_proto_pinocchio_chatapp_v1_chat_proto_init() }
@@ -2940,13 +3094,14 @@ func file_proto_pinocchio_chatapp_v1_chat_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc), len(file_proto_pinocchio_chatapp_v1_chat_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_proto_pinocchio_chatapp_v1_chat_proto_goTypes,
 		DependencyIndexes: file_proto_pinocchio_chatapp_v1_chat_proto_depIdxs,
+		EnumInfos:         file_proto_pinocchio_chatapp_v1_chat_proto_enumTypes,
 		MessageInfos:      file_proto_pinocchio_chatapp_v1_chat_proto_msgTypes,
 	}.Build()
 	File_proto_pinocchio_chatapp_v1_chat_proto = out.File

--- a/pkg/chatapp/plugins/reasoning.go
+++ b/pkg/chatapp/plugins/reasoning.go
@@ -15,8 +15,8 @@ import (
 const (
 	// ReasoningStartedEventName is the canonical backend event published when a reasoning segment begins.
 	ReasoningStartedEventName = chatapp.EventChatReasoningSegmentStarted
-	// ReasoningDeltaEventName is the canonical backend event published for each reasoning token delta.
-	ReasoningDeltaEventName = chatapp.EventChatReasoningDelta
+	// ReasoningPatchEventName is the canonical backend event published for each reasoning token delta.
+	ReasoningPatchEventName = chatapp.EventChatReasoningPatch
 	// ReasoningFinishedEventName is the canonical backend event published when a reasoning segment completes.
 	ReasoningFinishedEventName = chatapp.EventChatReasoningSegmentFinished
 
@@ -35,10 +35,10 @@ func NewReasoningPlugin() chatapp.ChatPlugin { return &ReasoningPlugin{} }
 func (p *ReasoningPlugin) RegisterSchemas(reg *sessionstream.SchemaRegistry) error {
 	for _, err := range []error{
 		reg.RegisterEvent(ReasoningStartedEventName, &chatappv1.ChatReasoningSegmentStarted{}),
-		reg.RegisterEvent(ReasoningDeltaEventName, &chatappv1.ChatReasoningDelta{}),
+		reg.RegisterEvent(ReasoningPatchEventName, &chatappv1.ChatReasoningPatch{}),
 		reg.RegisterEvent(ReasoningFinishedEventName, &chatappv1.ChatReasoningSegmentFinished{}),
 		reg.RegisterUIEvent(ReasoningStartedEventName, &chatappv1.ChatReasoningSegmentStarted{}),
-		reg.RegisterUIEvent(ReasoningDeltaEventName, &chatappv1.ChatReasoningDelta{}),
+		reg.RegisterUIEvent(ReasoningPatchEventName, &chatappv1.ChatReasoningPatch{}),
 		reg.RegisterUIEvent(ReasoningFinishedEventName, &chatappv1.ChatReasoningSegmentFinished{}),
 	} {
 		if err != nil {
@@ -67,15 +67,17 @@ func (p *ReasoningPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatap
 			Correlation:     chatapp.CorrelationInfoFromEvent(ev),
 		})
 	case *gepevents.EventReasoningDelta:
-		return true, runtime.Publish(ctx, ReasoningDeltaEventName, &chatappv1.ChatReasoningDelta{
-			MessageId:       reasoningMessageID(parentMessageID, ev.Correlation()),
+		messageID := reasoningMessageID(parentMessageID, ev.Correlation())
+		return true, runtime.Publish(ctx, ReasoningPatchEventName, &chatappv1.ChatReasoningPatch{
+			MessageId:       messageID,
 			ParentMessageId: parentMessageID,
 			Role:            "thinking",
-			Chunk:           ev.Delta,
-			Text:            ev.Text,
-			Content:         ev.Text,
+			StreamId:        messageID,
+			Sequence:        chatapp.Uint64FromInt64(ev.Sequence),
+			Offset:          chatapp.PatchOffset(ev.Text, ev.Delta),
+			Text:            ev.Delta,
+			Mode:            chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
 			Status:          "streaming",
-			Streaming:       true,
 			Source:          firstNonEmptyString(ev.Source, "thinking"),
 			Correlation:     chatapp.CorrelationInfoFromEvent(ev),
 		})
@@ -100,7 +102,7 @@ func (p *ReasoningPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatap
 // ProjectUI forwards canonical reasoning backend events as canonical UI events.
 func (p *ReasoningPlugin) ProjectUI(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, _ sessionstream.TimelineView) ([]sessionstream.UIEvent, bool, error) {
 	switch ev.Name {
-	case ReasoningStartedEventName, ReasoningDeltaEventName, ReasoningFinishedEventName:
+	case ReasoningStartedEventName, ReasoningPatchEventName, ReasoningFinishedEventName:
 		if ev.Payload == nil {
 			return nil, true, fmt.Errorf("reasoning payload must be proto message, got %T", ev.Payload)
 		}
@@ -168,8 +170,10 @@ func reasoningEntityFromEvent(ev sessionstream.Event, view sessionstream.Timelin
 	switch payload := ev.Payload.(type) {
 	case *chatappv1.ChatReasoningSegmentStarted:
 		return reasoningEntityFromFields(view, payload.GetMessageId(), payload.GetParentMessageId(), payload.GetRole(), "", "", payload.GetStatus(), payload.GetStreaming(), payload.GetCorrelation(), ev.Name)
-	case *chatappv1.ChatReasoningDelta:
-		return reasoningEntityFromFields(view, payload.GetMessageId(), payload.GetParentMessageId(), payload.GetRole(), payload.GetContent(), payload.GetText(), payload.GetStatus(), payload.GetStreaming(), payload.GetCorrelation(), ev.Name)
+	case *chatappv1.ChatReasoningPatch:
+		entity, _ := currentReasoningEntity(view, payload.GetMessageId())
+		content := chatapp.ApplyStreamPatch(firstNonEmptyString(entity.GetContent(), entity.GetText()), payload.GetText(), payload.GetMode())
+		return reasoningEntityFromFields(view, payload.GetMessageId(), payload.GetParentMessageId(), payload.GetRole(), content, content, payload.GetStatus(), !payload.GetFinal(), payload.GetCorrelation(), ev.Name)
 	case *chatappv1.ChatReasoningSegmentFinished:
 		return reasoningEntityFromFields(view, payload.GetMessageId(), payload.GetParentMessageId(), payload.GetRole(), payload.GetContent(), payload.GetText(), payload.GetStatus(), payload.GetStreaming(), payload.GetCorrelation(), ev.Name)
 	default:
@@ -198,7 +202,7 @@ func reasoningEntityFromFields(view sessionstream.TimelineView, messageID, paren
 	entity.Correlation = chatapp.MergeCorrelationInfo(entity.GetCorrelation(), corr)
 	entity.SegmentType = gepevents.SegmentTypeReasoning
 	switch eventName {
-	case ReasoningStartedEventName, ReasoningDeltaEventName:
+	case ReasoningStartedEventName, ReasoningPatchEventName:
 		entity.Status = firstNonEmptyString(status, "streaming")
 		entity.Streaming = streaming
 	case ReasoningFinishedEventName:

--- a/pkg/chatapp/plugins/reasoning_test.go
+++ b/pkg/chatapp/plugins/reasoning_test.go
@@ -49,10 +49,10 @@ func TestReasoningPluginPublishesCanonicalReasoningEvents(t *testing.T) {
 	require.Equal(t, "chat-msg-1", started.GetParentMessageId())
 	require.Equal(t, "reasoning-segment-1", started.GetCorrelation().GetSegmentId())
 
-	require.Equal(t, chatapp.EventChatReasoningDelta, published[1].Name)
-	delta := published[1].Payload.(*chatappv1.ChatReasoningDelta)
-	require.Equal(t, "draft", delta.GetChunk())
-	require.Equal(t, "draft plan", delta.GetText())
+	require.Equal(t, chatapp.EventChatReasoningPatch, published[1].Name)
+	delta := published[1].Payload.(*chatappv1.ChatReasoningPatch)
+	require.Equal(t, "draft", delta.GetText())
+	require.Equal(t, chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, delta.GetMode())
 	require.Equal(t, "reasoning-segment-1", delta.GetCorrelation().GetSegmentId())
 	require.Equal(t, "summary", delta.GetSource())
 
@@ -83,7 +83,7 @@ func TestReasoningPluginRoutesReasoningByStableSegmentIdentity(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, published, 2)
-	delta := published[0].Payload.(*chatappv1.ChatReasoningDelta)
+	delta := published[0].Payload.(*chatappv1.ChatReasoningPatch)
 	finished := published[1].Payload.(*chatappv1.ChatReasoningSegmentFinished)
 	require.Equal(t, delta.GetMessageId(), finished.GetMessageId())
 	require.Equal(t, "chat-msg-1:thinking:reasoning-rs-1", finished.GetMessageId())
@@ -213,12 +213,11 @@ func TestReasoningPluginSparseProjectionMatrix(t *testing.T) {
 				Streaming:       true,
 				Correlation:     fullCorr,
 			}),
-			event: sessionstream.Event{Name: ReasoningDeltaEventName, SessionId: "sid", Payload: &chatappv1.ChatReasoningDelta{
+			event: sessionstream.Event{Name: ReasoningPatchEventName, SessionId: "sid", Payload: &chatappv1.ChatReasoningPatch{
 				MessageId:   "chat-msg-1:thinking:reasoning-segment-1",
-				Content:     "partial plan",
-				Text:        "partial plan",
+				Text:        " plan",
+				Mode:        chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
 				Status:      "streaming",
-				Streaming:   true,
 				Correlation: segmentOnlyCorr,
 			}},
 			check: func(t *testing.T, entity *chatappv1.ChatMessageEntity) {

--- a/pkg/chatapp/plugins/toolcall.go
+++ b/pkg/chatapp/plugins/toolcall.go
@@ -14,8 +14,8 @@ import (
 const (
 	// EventToolCallStarted is published when the model starts a tool call.
 	EventToolCallStarted = chatapp.EventChatToolCallStarted
-	// EventToolCallArgumentsDelta is published for streamed tool-call arguments.
-	EventToolCallArgumentsDelta = chatapp.EventChatToolCallArgumentsDelta
+	// EventToolArgumentsPatch is published for streamed tool-call arguments.
+	EventToolArgumentsPatch = chatapp.EventChatToolArgumentsPatch
 	// EventToolCallRequested is published when the model has fully requested a tool call.
 	EventToolCallRequested = chatapp.EventChatToolCallRequested
 	// EventToolExecutionStarted is published when host-side tool execution begins.
@@ -42,13 +42,13 @@ func NewToolCallPlugin() chatapp.ChatPlugin { return &ToolCallPlugin{} }
 func (p *ToolCallPlugin) RegisterSchemas(reg *sessionstream.SchemaRegistry) error {
 	for _, err := range []error{
 		reg.RegisterEvent(EventToolCallStarted, &chatappv1.ChatToolCallStarted{}),
-		reg.RegisterEvent(EventToolCallArgumentsDelta, &chatappv1.ChatToolCallArgumentsDelta{}),
+		reg.RegisterEvent(EventToolArgumentsPatch, &chatappv1.ChatToolArgumentsPatch{}),
 		reg.RegisterEvent(EventToolCallRequested, &chatappv1.ChatToolCallRequested{}),
 		reg.RegisterEvent(EventToolExecutionStarted, &chatappv1.ChatToolExecutionStarted{}),
 		reg.RegisterEvent(EventToolResultReady, &chatappv1.ChatToolResultReady{}),
 		reg.RegisterEvent(EventToolCallFinished, &chatappv1.ChatToolCallFinished{}),
 		reg.RegisterUIEvent(EventToolCallStarted, &chatappv1.ChatToolCallStarted{}),
-		reg.RegisterUIEvent(EventToolCallArgumentsDelta, &chatappv1.ChatToolCallArgumentsDelta{}),
+		reg.RegisterUIEvent(EventToolArgumentsPatch, &chatappv1.ChatToolArgumentsPatch{}),
 		reg.RegisterUIEvent(EventToolCallRequested, &chatappv1.ChatToolCallRequested{}),
 		reg.RegisterUIEvent(EventToolExecutionStarted, &chatappv1.ChatToolExecutionStarted{}),
 		reg.RegisterUIEvent(EventToolResultReady, &chatappv1.ChatToolResultReady{}),
@@ -69,7 +69,7 @@ func (p *ToolCallPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatapp
 	case *gepevents.EventToolCallStarted:
 		return true, runtime.Publish(ctx, EventToolCallStarted, &chatappv1.ChatToolCallStarted{MessageId: runtime.MessageID, ToolCallId: ev.ToolCallID, ToolName: ev.ToolName, Status: "pending", Correlation: chatapp.CorrelationInfoFromEvent(ev)})
 	case *gepevents.EventToolCallArgumentsDelta:
-		return true, runtime.Publish(ctx, EventToolCallArgumentsDelta, &chatappv1.ChatToolCallArgumentsDelta{MessageId: runtime.MessageID, ToolCallId: ev.ToolCallID, ArgumentsDelta: ev.Delta, Input: ev.Arguments, Status: "streaming_args", Correlation: chatapp.CorrelationInfoFromEvent(ev)})
+		return true, runtime.Publish(ctx, EventToolArgumentsPatch, &chatappv1.ChatToolArgumentsPatch{MessageId: runtime.MessageID, ToolCallId: ev.ToolCallID, StreamId: ev.ToolCallID, Sequence: chatapp.Uint64FromInt64(ev.Sequence), Offset: chatapp.PatchOffset(ev.Arguments, ev.Delta), Arguments: ev.Delta, Mode: chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, Status: "streaming_args", Correlation: chatapp.CorrelationInfoFromEvent(ev)})
 	case *gepevents.EventToolCallRequested:
 		return true, runtime.Publish(ctx, EventToolCallRequested, &chatappv1.ChatToolCallRequested{MessageId: runtime.MessageID, ToolCallId: ev.ToolCallID, ToolName: ev.ToolName, Input: ev.Input, Status: "pending", Correlation: chatapp.CorrelationInfoFromEvent(ev)})
 	case *gepevents.EventToolExecutionStarted:
@@ -86,7 +86,7 @@ func (p *ToolCallPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatapp
 // ProjectUI forwards canonical tool backend events as canonical UI events.
 func (p *ToolCallPlugin) ProjectUI(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, _ sessionstream.TimelineView) ([]sessionstream.UIEvent, bool, error) {
 	switch ev.Name {
-	case EventToolCallStarted, EventToolCallArgumentsDelta, EventToolCallRequested, EventToolExecutionStarted, EventToolResultReady, EventToolCallFinished:
+	case EventToolCallStarted, EventToolArgumentsPatch, EventToolCallRequested, EventToolExecutionStarted, EventToolResultReady, EventToolCallFinished:
 		if ev.Payload == nil {
 			return nil, true, fmt.Errorf("tool payload must be proto message, got %T", ev.Payload)
 		}
@@ -99,7 +99,7 @@ func (p *ToolCallPlugin) ProjectUI(_ context.Context, ev sessionstream.Event, _ 
 // ProjectTimeline projects tool call backend events into timeline entities.
 func (p *ToolCallPlugin) ProjectTimeline(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, view sessionstream.TimelineView) ([]sessionstream.TimelineEntity, bool, error) {
 	switch ev.Name {
-	case EventToolCallStarted, EventToolCallArgumentsDelta, EventToolCallRequested, EventToolExecutionStarted, EventToolCallFinished:
+	case EventToolCallStarted, EventToolArgumentsPatch, EventToolCallRequested, EventToolExecutionStarted, EventToolCallFinished:
 		payload, ok := toolCallFieldsFromCanonical(ev)
 		if !ok {
 			return nil, true, fmt.Errorf("unexpected tool call payload %T", ev.Payload)
@@ -146,8 +146,8 @@ func toolCallFieldsFromCanonical(ev sessionstream.Event) (toolCallFields, bool) 
 	switch payload := ev.Payload.(type) {
 	case *chatappv1.ChatToolCallStarted:
 		return toolCallFields{MessageID: payload.GetMessageId(), ToolCallID: payload.GetToolCallId(), ToolName: payload.GetToolName(), Input: payload.GetInput(), Executing: payload.GetExecuting(), Status: firstNonEmptyString(payload.GetStatus(), "pending"), Correlation: payload.GetCorrelation()}, true
-	case *chatappv1.ChatToolCallArgumentsDelta:
-		return toolCallFields{MessageID: payload.GetMessageId(), ToolCallID: payload.GetToolCallId(), ToolName: payload.GetToolName(), Input: payload.GetInput(), Status: firstNonEmptyString(payload.GetStatus(), "streaming_args"), Correlation: payload.GetCorrelation()}, true
+	case *chatappv1.ChatToolArgumentsPatch:
+		return toolCallFields{MessageID: payload.GetMessageId(), ToolCallID: payload.GetToolCallId(), ToolName: payload.GetToolName(), Input: payload.GetArguments(), Status: firstNonEmptyString(payload.GetStatus(), "streaming_args"), Correlation: payload.GetCorrelation()}, true
 	case *chatappv1.ChatToolCallRequested:
 		return toolCallFields{MessageID: payload.GetMessageId(), ToolCallID: payload.GetToolCallId(), ToolName: payload.GetToolName(), Input: payload.GetInput(), Executing: payload.GetExecuting(), Status: firstNonEmptyString(payload.GetStatus(), "pending"), Correlation: payload.GetCorrelation()}, true
 	case *chatappv1.ChatToolExecutionStarted:
@@ -188,7 +188,11 @@ func mergeToolCallFields(entity *chatappv1.ToolCallEntity, update toolCallFields
 		entity.ToolName = update.ToolName
 	}
 	if update.Input != "" {
-		entity.Input = update.Input
+		if update.Status == "streaming_args" {
+			entity.Input += update.Input
+		} else {
+			entity.Input = update.Input
+		}
 	}
 	entity.Executing = update.Executing
 	if update.Status != "" {

--- a/pkg/chatapp/plugins/toolcall_test.go
+++ b/pkg/chatapp/plugins/toolcall_test.go
@@ -52,10 +52,10 @@ func TestToolCallPluginPublishesCanonicalToolEvents(t *testing.T) {
 	require.Equal(t, "lookup", started.GetToolName())
 	require.Equal(t, "call-1", started.GetCorrelation().GetToolCallId())
 
-	require.Equal(t, chatapp.EventChatToolCallArgumentsDelta, published[1].Name)
-	args := published[1].Payload.(*chatappv1.ChatToolCallArgumentsDelta)
-	require.Equal(t, `{"symbol"`, args.GetArgumentsDelta())
-	require.Equal(t, `{"symbol":"BTC"}`, args.GetInput())
+	require.Equal(t, chatapp.EventChatToolArgumentsPatch, published[1].Name)
+	args := published[1].Payload.(*chatappv1.ChatToolArgumentsPatch)
+	require.Equal(t, `{"symbol"`, args.GetArguments())
+	require.Equal(t, chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, args.GetMode())
 
 	require.Equal(t, chatapp.EventChatToolResultReady, published[4].Name)
 	result := published[4].Payload.(*chatappv1.ChatToolResultReady)
@@ -187,18 +187,19 @@ func TestToolCallPluginSparseProjectionMatrix(t *testing.T) {
 						MessageId:   "chat-msg-tool",
 						ToolCallId:  "call-sparse",
 						ToolName:    "inventory",
+						Input:       `{"coin":`,
 						Status:      "pending",
 						Correlation: fullCorr,
 					},
 				},
 			}},
-			event: sessionstream.Event{Name: EventToolCallArgumentsDelta, SessionId: "sid", Payload: &chatappv1.ChatToolCallArgumentsDelta{
-				MessageId:      "chat-msg-tool",
-				ToolCallId:     "call-sparse",
-				ArgumentsDelta: `"ETH"}`,
-				Input:          `{"coin":"ETH"}`,
-				Status:         "streaming_args",
-				Correlation:    segmentOnlyCorr,
+			event: sessionstream.Event{Name: EventToolArgumentsPatch, SessionId: "sid", Payload: &chatappv1.ChatToolArgumentsPatch{
+				MessageId:   "chat-msg-tool",
+				ToolCallId:  "call-sparse",
+				Arguments:   `"ETH"}`,
+				Mode:        chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
+				Status:      "streaming_args",
+				Correlation: segmentOnlyCorr,
 			}},
 			check: func(t *testing.T, entity *chatappv1.ToolCallEntity) {
 				t.Helper()

--- a/pkg/chatapp/projections.go
+++ b/pkg/chatapp/projections.go
@@ -17,7 +17,7 @@ func baseUIProjection(_ context.Context, ev sessionstream.Event, _ *sessionstrea
 	case EventUserMessageAccepted,
 		EventChatRunStarted, EventChatRunFinished, EventChatRunStopped, EventChatRunFailed,
 		EventChatProviderCallStarted, EventChatProviderCallMetadataUpdated, EventChatProviderCallFinished,
-		EventChatTextSegmentStarted, EventChatTextDelta, EventChatTextSegmentFinished:
+		EventChatTextSegmentStarted, EventChatTextPatch, EventChatTextSegmentFinished:
 		return []sessionstream.UIEvent{{Name: ev.Name, Payload: proto.Clone(ev.Payload)}}, nil
 	default:
 		return nil, nil
@@ -61,23 +61,24 @@ func baseTimelineProjection(_ context.Context, ev sessionstream.Event, _ *sessio
 		entity.ParentMessageId = parentMessageIDFromSegmentMessageID(messageID)
 		entity.Correlation = MergeCorrelationInfo(entity.GetCorrelation(), payload.GetCorrelation())
 		return []sessionstream.TimelineEntity{{Kind: TimelineEntityChatMessage, Id: messageID, Payload: entity}}, nil
-	case *chatappv1.ChatTextDelta:
+	case *chatappv1.ChatTextPatch:
 		messageID := strings.TrimSpace(payload.GetMessageId())
 		if messageID == "" {
 			return nil, nil
 		}
-		content := firstNonEmpty(payload.GetContent(), payload.GetText())
+		entity, _ := currentChatMessageEntity(view, messageID)
+		content := ApplyStreamPatch(firstNonEmpty(entity.GetContent(), entity.GetText()), payload.GetText(), payload.GetMode())
 		if content == "" {
 			return nil, nil
 		}
-		entity, _ := currentChatMessageEntity(view, messageID)
 		entity.MessageId = messageID
 		entity.Role = firstNonEmpty(payload.GetRole(), "assistant")
 		entity.Prompt = firstNonEmpty(payload.GetPrompt(), entity.GetPrompt())
 		entity.Content = content
 		entity.Text = content
 		entity.Status = firstNonEmpty(payload.GetStatus(), "streaming")
-		entity.Streaming = payload.GetStreaming()
+		entity.Streaming = !payload.GetFinal()
+		entity.Final = payload.GetFinal()
 		entity.ParentMessageId = parentMessageIDFromSegmentMessageID(messageID)
 		entity.Correlation = MergeCorrelationInfo(entity.GetCorrelation(), payload.GetCorrelation())
 		return []sessionstream.TimelineEntity{{Kind: TimelineEntityChatMessage, Id: messageID, Payload: entity}}, nil
@@ -126,4 +127,17 @@ func currentChatMessageEntity(view sessionstream.TimelineView, id string) (*chat
 		return &chatappv1.ChatMessageEntity{}, false
 	}
 	return proto.Clone(pb).(*chatappv1.ChatMessageEntity), true
+}
+
+func ApplyStreamPatch(current, patch string, mode chatappv1.ChatStreamPatchMode) string {
+	switch mode {
+	case chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_SNAPSHOT,
+		chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_REPLACE:
+		return patch
+	case chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
+		chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_UNSPECIFIED:
+		fallthrough
+	default:
+		return current + patch
+	}
 }

--- a/pkg/chatapp/projections_protocol_test.go
+++ b/pkg/chatapp/projections_protocol_test.go
@@ -80,12 +80,11 @@ func TestBaseTimelineProjectionSparseTextMatrix(t *testing.T) {
 				Streaming:   true,
 				Correlation: fullCorr,
 			}),
-			event: sessionstream.Event{Name: EventChatTextDelta, SessionId: "session-1", Payload: &chatappv1.ChatTextDelta{
+			event: sessionstream.Event{Name: EventChatTextPatch, SessionId: "session-1", Payload: &chatappv1.ChatTextPatch{
 				MessageId:   "message-1:text:segment-1",
-				Content:     "partial answer",
-				Text:        "partial answer",
+				Text:        " answer",
+				Mode:        chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND,
 				Status:      "streaming",
-				Streaming:   true,
 				Correlation: segmentOnlyCorr,
 			}},
 			check: func(t *testing.T, entity *chatappv1.ChatMessageEntity) {

--- a/pkg/chatapp/runtime_sink.go
+++ b/pkg/chatapp/runtime_sink.go
@@ -206,5 +206,13 @@ func PatchOffset(snapshot, delta string) uint64 {
 	if delta == "" || len(snapshot) < len(delta) {
 		return 0
 	}
-	return uint64(len(snapshot) - len(delta))
+	return Uint64FromInt(len(snapshot) - len(delta))
+}
+
+func Uint64FromInt(value int) uint64 {
+	if value <= 0 {
+		return 0
+	}
+	// #nosec G115 -- value is non-negative and Go int fits in uint64 on supported architectures.
+	return uint64(value)
 }

--- a/pkg/chatapp/runtime_sink.go
+++ b/pkg/chatapp/runtime_sink.go
@@ -56,7 +56,7 @@ func (s *runtimeEventSink) PublishEvent(event gepevents.Event) error {
 		s.lastTextCorrelation = corr
 		s.textActive = true
 		s.mu.Unlock()
-		return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventChatTextDelta, &chatappv1.ChatTextDelta{MessageId: textMessageID, Role: "assistant", Prompt: s.prompt, Chunk: ev.Delta, Text: ev.Text, Content: ev.Text, Status: "streaming", Streaming: true, Correlation: correlationInfoFromEvent(ev)})
+		return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventChatTextPatch, &chatappv1.ChatTextPatch{MessageId: textMessageID, Role: "assistant", Prompt: s.prompt, StreamId: textMessageID, Sequence: Uint64FromInt64(ev.Sequence), Offset: PatchOffset(ev.Text, ev.Delta), Text: ev.Delta, Mode: chatappv1.ChatStreamPatchMode_CHAT_STREAM_PATCH_MODE_APPEND, Status: "streaming", Correlation: correlationInfoFromEvent(ev)})
 	case *gepevents.EventTextSegmentFinished:
 		corr := ev.Correlation()
 		textMessageID, _ := s.textSegmentIDForCorrelation(corr)
@@ -193,4 +193,18 @@ func (s *runtimeEventSink) IsTerminal() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.terminal
+}
+
+func Uint64FromInt64(value int64) uint64 {
+	if value <= 0 {
+		return 0
+	}
+	return uint64(value)
+}
+
+func PatchOffset(snapshot, delta string) uint64 {
+	if delta == "" || len(snapshot) < len(delta) {
+		return 0
+	}
+	return uint64(len(snapshot) - len(delta))
 }

--- a/pkg/chatapp/runtime_sink_protocol_test.go
+++ b/pkg/chatapp/runtime_sink_protocol_test.go
@@ -38,7 +38,7 @@ func TestRuntimeEventSinkProtocolMatrix(t *testing.T) {
 				gepevents.NewTextDeltaEvent(metadata, textCorr, "partial", "partial", 1),
 				gepevents.NewErrorEvent(metadata, errors.New("stream exploded")),
 			},
-			wantNames: []string{EventChatTextSegmentStarted, EventChatTextDelta, EventChatTextSegmentFinished, EventChatRunFailed},
+			wantNames: []string{EventChatTextSegmentStarted, EventChatTextPatch, EventChatTextSegmentFinished, EventChatRunFailed},
 			check: func(t *testing.T, published []sessionstream.Event, sink *runtimeEventSink) {
 				t.Helper()
 				finished := published[2].Payload.(*chatappv1.ChatTextSegmentFinished)
@@ -63,7 +63,7 @@ func TestRuntimeEventSinkProtocolMatrix(t *testing.T) {
 				gepevents.NewTextDeltaEvent(metadata, textCorr, "partial", "partial", 1),
 				gepevents.NewInterruptEvent(metadata, ""),
 			},
-			wantNames: []string{EventChatTextSegmentStarted, EventChatTextDelta, EventChatTextSegmentFinished, EventChatRunStopped},
+			wantNames: []string{EventChatTextSegmentStarted, EventChatTextPatch, EventChatTextSegmentFinished, EventChatRunStopped},
 			check: func(t *testing.T, published []sessionstream.Event, sink *runtimeEventSink) {
 				t.Helper()
 				finished := published[2].Payload.(*chatappv1.ChatTextSegmentFinished)
@@ -85,7 +85,7 @@ func TestRuntimeEventSinkProtocolMatrix(t *testing.T) {
 				gepevents.NewTextSegmentFinishedEvent(metadata, textCorr, "done", "stop"),
 				gepevents.NewErrorEvent(metadata, errors.New("late error")),
 			},
-			wantNames: []string{EventChatTextSegmentStarted, EventChatTextDelta, EventChatTextSegmentFinished, EventChatRunFailed},
+			wantNames: []string{EventChatTextSegmentStarted, EventChatTextPatch, EventChatTextSegmentFinished, EventChatRunFailed},
 			check: func(t *testing.T, published []sessionstream.Event, _ *runtimeEventSink) {
 				t.Helper()
 				finished := published[2].Payload.(*chatappv1.ChatTextSegmentFinished)
@@ -117,7 +117,7 @@ func TestRuntimeEventSinkProtocolMatrix(t *testing.T) {
 				gepevents.NewTextSegmentFinishedEvent(metadata, textCorr, "done", "stop"),
 				gepevents.NewProviderCallFinishedEvent(metadata, providerCorr, "stop", "completed", nil, nil, false),
 			},
-			wantNames: []string{EventChatTextSegmentStarted, EventChatTextDelta, EventChatTextSegmentFinished, EventChatProviderCallFinished},
+			wantNames: []string{EventChatTextSegmentStarted, EventChatTextPatch, EventChatTextSegmentFinished, EventChatProviderCallFinished},
 			check: func(t *testing.T, published []sessionstream.Event, _ *runtimeEventSink) {
 				t.Helper()
 				requireRuntimeSinkEventCount(t, published, EventChatTextSegmentFinished, 1)

--- a/proto/pinocchio/chatapp/v1/chat.proto
+++ b/proto/pinocchio/chatapp/v1/chat.proto
@@ -85,16 +85,26 @@ message ChatTextSegmentStarted {
   CorrelationInfo correlation = 6;
 }
 
-message ChatTextDelta {
+enum ChatStreamPatchMode {
+  CHAT_STREAM_PATCH_MODE_UNSPECIFIED = 0;
+  CHAT_STREAM_PATCH_MODE_APPEND = 1;
+  CHAT_STREAM_PATCH_MODE_SNAPSHOT = 2;
+  CHAT_STREAM_PATCH_MODE_REPLACE = 3;
+}
+
+message ChatTextPatch {
   string message_id = 1;
   string role = 2;
-  string prompt = 3;
-  string chunk = 4;
-  string text = 5;
-  string content = 6;
-  string status = 7;
-  bool streaming = 8;
-  CorrelationInfo correlation = 9;
+  string stream_id = 3;
+  uint64 sequence = 4;
+  uint64 offset = 5;
+  string text = 6;
+  ChatStreamPatchMode mode = 7;
+  string status = 8;
+  bool final = 9;
+  string finish_reason = 10;
+  string prompt = 11;
+  CorrelationInfo correlation = 12;
 }
 
 message ChatTextSegmentFinished {
@@ -120,17 +130,20 @@ message ChatReasoningSegmentStarted {
   CorrelationInfo correlation = 7;
 }
 
-message ChatReasoningDelta {
+message ChatReasoningPatch {
   string message_id = 1;
   string parent_message_id = 2;
   string role = 3;
-  string chunk = 4;
-  string text = 5;
-  string content = 6;
-  string status = 7;
-  bool streaming = 8;
-  string source = 9;
-  CorrelationInfo correlation = 10;
+  string stream_id = 4;
+  uint64 sequence = 5;
+  uint64 offset = 6;
+  string text = 7;
+  ChatStreamPatchMode mode = 8;
+  string status = 9;
+  bool final = 10;
+  string source = 11;
+  string finish_reason = 12;
+  CorrelationInfo correlation = 13;
 }
 
 message ChatReasoningSegmentFinished {
@@ -156,14 +169,18 @@ message ChatToolCallStarted {
   CorrelationInfo correlation = 7;
 }
 
-message ChatToolCallArgumentsDelta {
+message ChatToolArgumentsPatch {
   string message_id = 1;
   string tool_call_id = 2;
   string tool_name = 3;
-  string arguments_delta = 4;
-  string input = 5;
-  string status = 6;
-  CorrelationInfo correlation = 7;
+  string stream_id = 4;
+  uint64 sequence = 5;
+  uint64 offset = 6;
+  string arguments = 7;
+  ChatStreamPatchMode mode = 8;
+  string status = 9;
+  bool final = 10;
+  CorrelationInfo correlation = 11;
 }
 
 message ChatToolCallRequested {


### PR DESCRIPTION
This pull request overhauls the real-time streaming protocol, replacing the
existing `*Delta` events with a more structured and robust `*Patch` system. The
previous implementation relied on simple, append-only delta messages. The new
patch protocol introduces explicit stream management, making our real-time
communication more resilient and extensible.

**Key Changes:**

**Protocol (Protobuf):**
- Renamed `ChatTextDelta`, `ChatReasoningDelta`, and
  `ChatToolCallArgumentsDelta` to their `*Patch` equivalents (e.g.,
  `ChatTextPatch`).
- Introduced a `ChatStreamPatchMode` enum (`APPEND`, `SNAPSHOT`, `REPLACE`) to
  specify how a patch should be applied by the client.
- Added fields for robust stream handling: `stream_id`, `sequence`, `offset`,
  and a `final` flag to signal the end of a stream.
- Standardized content fields, removing ambiguity between `chunk`, `text`, and
  `content`.

**Backend:**
- Updated backend plugins and the demo engine to publish the new `*Patch`
  events.
- Event publishing now includes sequencing and mode information, providing
  clearer instructions to the client.

**Frontend:**
- The timeline store logic is updated to handle patch-based updates. It now
  correctly appends partial content from `APPEND` patches to existing messages.
- Event handlers now transform incoming `*Patch` events into the appropriate
  mutations for the UI state.
- The `streaming` status of a message is now derived from the `final` flag in
  the patch event.