### PR TITLE
Add docsctl documentation publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,3 +123,24 @@ jobs:
           TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+
+  publish-docs:
+    name: Publish docs
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+      - goreleaser-merge
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    uses: go-go-golems/infra-tooling/.github/workflows/publish-docsctl.yml@main
+    with:
+      package_name: pinocchio
+      package_version: ${{ github.ref_name }}
+      export_command: GOWORK=off go run ./cmd/pinocchio help export --format sqlite --output-path .docsctl/help.sqlite
+      sqlite_path: .docsctl/help.sqlite
+      docsctl_install_command: go install github.com/go-go-golems/glazed/cmd/docsctl@latest
+      vault_role: docsctl-pinocchio-publisher
+      vault_token_role: docsctl-pinocchio-publisher
+      registry_url: https://docs-registry.yolo.scapegoat.dev
+      verify_packages_url: https://docs.yolo.scapegoat.dev/api/packages
+      verify_publish: true


### PR DESCRIPTION
## Summary\n- add release workflow docs publishing via go-go-golems/infra-tooling/.github/workflows/publish-docsctl.yml@main\n- grant GitHub OIDC id-token permission for Vault auth\n- export and publish Glazed help SQLite on release tags\n\n## Validation\n- local help SQLite export succeeded\n- docsctl validate succeeded with package/version identity\n- workflow YAML parsed successfully\n\n## Notes\n- Requires matching Vault docsctl publisher role before the next release tag publishes docs.