### PR TITLE
Surface and persist chat run errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/go-go-golems/pinocchio
 
-go 1.26.3
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	charm.land/lipgloss/v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-go-golems/pinocchio
 
-go 1.26
+go 1.26.1
 
 toolchain go1.26.4
 
@@ -23,6 +23,7 @@ require (
 	github.com/go-go-golems/uhoh v0.0.8
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/invopop/jsonschema v0.13.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/pkg/errors v0.9.1
@@ -102,7 +103,6 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hashicorp/vault/api v1.20.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/pkg/chatapp/chat_test.go
+++ b/pkg/chatapp/chat_test.go
@@ -383,7 +383,53 @@ func TestRuntimeErrorAfterPartialStopsActiveTextSegment(t *testing.T) {
 	require.False(t, textSegment.GetStreaming())
 	require.Equal(t, "chat-msg-1", textSegment.GetParentMessageId())
 	require.True(t, textSegment.GetFinal())
-	require.NotContains(t, ids, "chat-msg-1")
+
+	failure := ids["chat-msg-1"]
+	require.NotNil(t, failure)
+	require.Equal(t, "error", failure.GetRole())
+	require.Equal(t, "failed", failure.GetStatus())
+	require.Contains(t, failure.GetContent(), "provider failed after partial")
+}
+
+func TestRuntimeFailureWithoutTextProjectsRunFailureAndPersistsFailedTurn(t *testing.T) {
+	store := &fakeTurnStore{}
+	engine := NewEngine(WithChunkDelay(time.Millisecond), WithTurnStore(store))
+	hub := newTestHub(t, engine)
+	engine.setPendingRequest("request-immediate-error", PromptRequest{
+		Prompt: "Fail before text",
+		Runtime: &infruntime.ComposedRuntime{
+			Engine:     immediateErrorEngine{},
+			RuntimeKey: "runtime-test",
+		},
+	})
+
+	require.NoError(t, hub.Submit(context.Background(), sessionstream.SessionId("chat-immediate-error"), CommandStartInference, &chatappv1.StartInferenceCommand{RequestId: "request-immediate-error"}))
+	require.NoError(t, engine.WaitIdle(context.Background(), sessionstream.SessionId("chat-immediate-error")))
+
+	snap, err := hub.Snapshot(context.Background(), sessionstream.SessionId("chat-immediate-error"))
+	require.NoError(t, err)
+
+	ids := map[string]*chatappv1.ChatMessageEntity{}
+	for _, entity := range snap.Entities {
+		if entity.Kind != TimelineEntityChatMessage {
+			continue
+		}
+		ids[entity.Id] = entity.Payload.(*chatappv1.ChatMessageEntity)
+	}
+
+	failure := ids["chat-msg-1"]
+	require.NotNil(t, failure)
+	require.Equal(t, "error", failure.GetRole())
+	require.Equal(t, "failed", failure.GetStatus())
+	require.Contains(t, failure.GetContent(), "provider rejected request")
+	require.False(t, failure.GetStreaming())
+	require.True(t, failure.GetFinal())
+
+	require.Len(t, store.saves, 1)
+	require.Equal(t, "failed", store.saves[0].phase)
+	require.Equal(t, "chat-immediate-error", store.saves[0].sessionID)
+	require.Equal(t, "runtime-test", store.saves[0].opts.RuntimeKey)
+	require.Contains(t, store.saves[0].payload, "Fail before text")
 }
 
 func TestRuntimeInterruptAfterPartialStopsActiveTextSegment(t *testing.T) {
@@ -492,7 +538,11 @@ func TestRuntimeErrorAfterClosedTextSegmentDoesNotDuplicateSegmentContent(t *tes
 	require.Equal(t, "finished", finishedSegment.GetStatus())
 	require.False(t, finishedSegment.GetStreaming())
 
-	require.NotContains(t, ids, "chat-msg-1")
+	failure := ids["chat-msg-1"]
+	require.NotNil(t, failure)
+	require.Equal(t, "error", failure.GetRole())
+	require.Equal(t, "failed", failure.GetStatus())
+	require.Contains(t, failure.GetContent(), "provider failed after boundary")
 }
 
 func TestRuntimeMaxIterationsErrorPublishesWarningMessage(t *testing.T) {
@@ -622,6 +672,12 @@ func (maxIterationsErrorEngine) RunInference(context.Context, *turns.Turn) (*tur
 	return nil, errors.New("max iterations (20) reached")
 }
 
+type immediateErrorEngine struct{}
+
+func (immediateErrorEngine) RunInference(_ context.Context, t *turns.Turn) (*turns.Turn, error) {
+	return t, errors.New("provider rejected request")
+}
+
 type recordingHistoryEngine struct {
 	seen      *turns.Turn
 	sessionID string
@@ -637,12 +693,24 @@ func (e *recordingHistoryEngine) RunInference(ctx context.Context, t *turns.Turn
 	return t, nil
 }
 
+type fakeTurnStoreSave struct {
+	convID      string
+	sessionID   string
+	turnID      string
+	phase       string
+	createdAtMs int64
+	payload     string
+	opts        chatstore.TurnSaveOptions
+}
+
 type fakeTurnStore struct {
 	snapshot *chatstore.TurnSnapshot
 	err      error
+	saves    []fakeTurnStoreSave
 }
 
-func (s *fakeTurnStore) Save(context.Context, string, string, string, string, int64, string, chatstore.TurnSaveOptions) error {
+func (s *fakeTurnStore) Save(_ context.Context, convID string, sessionID string, turnID string, phase string, createdAtMs int64, payload string, opts chatstore.TurnSaveOptions) error {
+	s.saves = append(s.saves, fakeTurnStoreSave{convID: convID, sessionID: sessionID, turnID: turnID, phase: phase, createdAtMs: createdAtMs, payload: payload, opts: opts})
 	return nil
 }
 

--- a/pkg/chatapp/chat_test.go
+++ b/pkg/chatapp/chat_test.go
@@ -432,6 +432,45 @@ func TestRuntimeFailureWithoutTextProjectsRunFailureAndPersistsFailedTurn(t *tes
 	require.Contains(t, store.saves[0].payload, "Fail before text")
 }
 
+func TestRuntimeEventErrorPersistsFailedTurnAfterTerminalSink(t *testing.T) {
+	store := &fakeTurnStore{}
+	engine := NewEngine(WithChunkDelay(time.Millisecond), WithTurnStore(store))
+	hub := newTestHub(t, engine)
+	engine.setPendingRequest("request-event-error", PromptRequest{
+		Prompt: "Fail through event sink",
+		Runtime: &infruntime.ComposedRuntime{
+			Engine:     eventErrorEngine{},
+			RuntimeKey: "runtime-event-error",
+		},
+	})
+
+	require.NoError(t, hub.Submit(context.Background(), sessionstream.SessionId("chat-event-error"), CommandStartInference, &chatappv1.StartInferenceCommand{RequestId: "request-event-error"}))
+	require.NoError(t, engine.WaitIdle(context.Background(), sessionstream.SessionId("chat-event-error")))
+
+	snap, err := hub.Snapshot(context.Background(), sessionstream.SessionId("chat-event-error"))
+	require.NoError(t, err)
+
+	ids := map[string]*chatappv1.ChatMessageEntity{}
+	for _, entity := range snap.Entities {
+		if entity.Kind != TimelineEntityChatMessage {
+			continue
+		}
+		ids[entity.Id] = entity.Payload.(*chatappv1.ChatMessageEntity)
+	}
+
+	failure := ids["chat-msg-1"]
+	require.NotNil(t, failure)
+	require.Equal(t, "error", failure.GetRole())
+	require.Equal(t, "failed", failure.GetStatus())
+	require.Contains(t, failure.GetContent(), "stream sink reported provider failure")
+
+	require.Len(t, store.saves, 1)
+	require.Equal(t, "failed", store.saves[0].phase)
+	require.Equal(t, "chat-event-error", store.saves[0].sessionID)
+	require.Equal(t, "runtime-event-error", store.saves[0].opts.RuntimeKey)
+	require.Contains(t, store.saves[0].payload, "Fail through event sink")
+}
+
 func TestRuntimeInterruptAfterPartialStopsActiveTextSegment(t *testing.T) {
 	engine := NewEngine(WithChunkDelay(time.Millisecond))
 	hub := newTestHub(t, engine)
@@ -676,6 +715,14 @@ type immediateErrorEngine struct{}
 
 func (immediateErrorEngine) RunInference(_ context.Context, t *turns.Turn) (*turns.Turn, error) {
 	return t, errors.New("provider rejected request")
+}
+
+type eventErrorEngine struct{}
+
+func (eventErrorEngine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, error) {
+	meta := gepevents.EventMetadata{SessionID: "sid"}
+	gepevents.PublishEventToContext(ctx, gepevents.NewErrorEvent(meta, errors.New("stream sink reported provider failure")))
+	return t, errors.New("provider failure returned after sink error")
 }
 
 type recordingHistoryEngine struct {

--- a/pkg/chatapp/projections.go
+++ b/pkg/chatapp/projections.go
@@ -41,6 +41,23 @@ func baseTimelineProjection(_ context.Context, ev sessionstream.Event, _ *sessio
 		}
 		entity.Text = entity.Content
 		return []sessionstream.TimelineEntity{{Kind: TimelineEntityChatMessage, Id: messageID, Payload: entity}}, nil
+	case *chatappv1.ChatRunFailed:
+		messageID := strings.TrimSpace(payload.GetMessageId())
+		if messageID == "" {
+			return nil, nil
+		}
+		content := firstNonEmpty(payload.GetError(), "Chat run failed")
+		entity := &chatappv1.ChatMessageEntity{
+			MessageId:   messageID,
+			Role:        "error",
+			Content:     content,
+			Text:        content,
+			Status:      firstNonEmpty(payload.GetStatus(), "failed"),
+			Streaming:   false,
+			Final:       true,
+			Correlation: payload.GetCorrelation(),
+		}
+		return []sessionstream.TimelineEntity{{Kind: TimelineEntityChatMessage, Id: messageID, Payload: entity}}, nil
 	case *chatappv1.ChatTextSegmentStarted:
 		messageID := strings.TrimSpace(payload.GetMessageId())
 		if messageID == "" {

--- a/pkg/chatapp/projections_protocol_test.go
+++ b/pkg/chatapp/projections_protocol_test.go
@@ -169,3 +169,24 @@ func requireProjectionFullCorrelation(t *testing.T, corr *chatappv1.CorrelationI
 	require.Equal(t, "provider-call-1", corr.GetProviderCallId())
 	require.Equal(t, "segment-1", corr.GetSegmentId())
 }
+
+func TestBaseTimelineProjectionProjectsRunFailure(t *testing.T) {
+	entities, err := baseTimelineProjection(context.Background(), sessionstream.Event{Name: EventChatRunFailed, SessionId: "chat-projection", Payload: &chatappv1.ChatRunFailed{
+		MessageId:   "chat-msg-1",
+		Status:      "failed",
+		Error:       "provider rejected tool name",
+		Correlation: &chatappv1.CorrelationInfo{SessionId: "chat-projection", RunId: "chat-msg-1"},
+	}}, nil, projectionTimelineView{})
+	require.NoError(t, err)
+	require.Len(t, entities, 1)
+	require.Equal(t, TimelineEntityChatMessage, entities[0].Kind)
+	require.Equal(t, "chat-msg-1", entities[0].Id)
+	payload := entities[0].Payload.(*chatappv1.ChatMessageEntity)
+	require.Equal(t, "error", payload.GetRole())
+	require.Equal(t, "failed", payload.GetStatus())
+	require.Equal(t, "provider rejected tool name", payload.GetContent())
+	require.Equal(t, "provider rejected tool name", payload.GetText())
+	require.False(t, payload.GetStreaming())
+	require.True(t, payload.GetFinal())
+	require.Equal(t, "chat-msg-1", payload.GetCorrelation().GetRunId())
+}

--- a/pkg/chatapp/runtime_inference.go
+++ b/pkg/chatapp/runtime_inference.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	gepevents "github.com/go-go-golems/geppetto/pkg/events"
 	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/turns"
 	"github.com/go-go-golems/geppetto/pkg/turns/serde"
 	chatappv1 "github.com/go-go-golems/pinocchio/pkg/chatapp/pb/proto/pinocchio/chatapp/v1"
+	chatstore "github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
 	sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
 	"google.golang.org/protobuf/proto"
 )
@@ -137,6 +139,7 @@ func (e *Engine) runRuntimeInference(ctx context.Context, sid sessionstream.Sess
 	assistantBlockOffset := countAssistantBlocks(sess.Latest())
 	handle, err := sess.StartInference(runCtx)
 	if err != nil {
+		e.persistRuntimeTurnSnapshot(publishContext(ctx), sid, runtime.RuntimeKey, "failed", sess.Latest())
 		e.publishRunFailed(publishContext(ctx), sid, pub, messageID, err.Error())
 		return
 	}
@@ -152,6 +155,7 @@ func (e *Engine) runRuntimeInference(ctx context.Context, sid sessionstream.Sess
 			if isMaxIterationsError(err) {
 				_ = e.publish(publishContext(ctx), sid, pub, EventChatTextSegmentFinished, &chatappv1.ChatTextSegmentFinished{MessageId: runtimeWarningMessageID(messageID), Role: "warning", Prompt: prompt, Text: maxIterationsWarningText(err), Content: maxIterationsWarningText(err), Status: "finished", Streaming: false, Final: true})
 			}
+			e.persistRuntimeTurnSnapshot(publishContext(ctx), sid, runtime.RuntimeKey, "failed", sess.Latest())
 			e.publishRunFailed(publishContext(ctx), sid, pub, messageID, err.Error())
 		}
 		return
@@ -235,6 +239,36 @@ func assistantTextFromTurnAfter(turn *turns.Turn, skip int) string {
 		parts = append(parts, text)
 	}
 	return strings.Join(parts, "")
+}
+
+func (e *Engine) persistRuntimeTurnSnapshot(ctx context.Context, sid sessionstream.SessionId, runtimeKey string, phase string, t *turns.Turn) {
+	if e == nil || e.turnStore == nil || t == nil || strings.TrimSpace(string(sid)) == "" {
+		return
+	}
+	turnID := strings.TrimSpace(t.ID)
+	if turnID == "" {
+		turnID = "turn"
+	}
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "snapshot"
+	}
+	runtimeKey = strings.TrimSpace(runtimeKey)
+	if runtimeKey == "" {
+		runtimeKey = "default"
+	}
+	payload, err := serde.ToYAML(t, serde.Options{})
+	if err != nil {
+		return
+	}
+	inferenceID := ""
+	if v, ok, err := turns.KeyTurnMetaInferenceID.Get(t.Metadata); err == nil && ok {
+		inferenceID = strings.TrimSpace(v)
+	}
+	_ = e.turnStore.Save(ctx, string(sid), string(sid), turnID, phase, time.Now().UnixMilli(), string(payload), chatstore.TurnSaveOptions{
+		RuntimeKey:  runtimeKey,
+		InferenceID: inferenceID,
+	})
 }
 
 func (e *Engine) publishRunFailed(ctx context.Context, sid sessionstream.SessionId, pub sessionstream.EventPublisher, messageID, errText string) {

--- a/pkg/chatapp/runtime_inference.go
+++ b/pkg/chatapp/runtime_inference.go
@@ -145,17 +145,19 @@ func (e *Engine) runRuntimeInference(ctx context.Context, sid sessionstream.Sess
 	}
 	output, err := handle.Wait()
 	if err != nil {
-		if !sink.IsTerminal() {
-			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			if !sink.IsTerminal() {
 				_ = sink.finishActiveTextSegment("stopped", "stopped", "")
 				_ = e.publish(publishContext(ctx), sid, pub, EventChatRunStopped, &chatappv1.ChatRunStopped{MessageId: messageID, Status: "stopped", Correlation: runCorrelationInfo(sid, messageID)})
-				return
 			}
+			return
+		}
+		e.persistRuntimeTurnSnapshot(publishContext(ctx), sid, runtime.RuntimeKey, "failed", sess.Latest())
+		if !sink.IsTerminal() {
 			_ = sink.finishActiveTextSegment("failed", "error", "")
 			if isMaxIterationsError(err) {
 				_ = e.publish(publishContext(ctx), sid, pub, EventChatTextSegmentFinished, &chatappv1.ChatTextSegmentFinished{MessageId: runtimeWarningMessageID(messageID), Role: "warning", Prompt: prompt, Text: maxIterationsWarningText(err), Content: maxIterationsWarningText(err), Status: "finished", Streaming: false, Final: true})
 			}
-			e.persistRuntimeTurnSnapshot(publishContext(ctx), sid, runtime.RuntimeKey, "failed", sess.Latest())
 			e.publishRunFailed(publishContext(ctx), sid, pub, messageID, err.Error())
 		}
 		return

--- a/pkg/chatapp/serverkit/turn_persistence.go
+++ b/pkg/chatapp/serverkit/turn_persistence.go
@@ -1,0 +1,100 @@
+package serverkit
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/go-go-golems/geppetto/pkg/inference/toolloop"
+	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/serde"
+	"github.com/go-go-golems/pinocchio/pkg/persistence/chatstore"
+	"github.com/pkg/errors"
+)
+
+// TurnStorePersister persists completed Geppetto turns into a chatstore.TurnStore.
+//
+// It is useful for chat applications that use enginebuilder.Builder and want the
+// successful final model-context accumulator to be available for debugging,
+// resume, export, or later conversation history loading.
+type TurnStorePersister struct {
+	store      chatstore.TurnStore
+	sessionID  string
+	runtimeKey string
+	phase      string
+}
+
+// NewTurnStorePersister creates an enginebuilder-compatible turn persister.
+// The session id is used as both conversation id and session id, matching the
+// web-chat/chatapp convention for per-session conversations.
+func NewTurnStorePersister(store chatstore.TurnStore, sessionID string, runtimeKey string, phase string) *TurnStorePersister {
+	if store == nil {
+		return nil
+	}
+	return &TurnStorePersister{
+		store:      store,
+		sessionID:  strings.TrimSpace(sessionID),
+		runtimeKey: strings.TrimSpace(runtimeKey),
+		phase:      strings.TrimSpace(phase),
+	}
+}
+
+func (p *TurnStorePersister) PersistTurn(ctx context.Context, t *turns.Turn) error {
+	if p == nil || p.store == nil || t == nil {
+		return nil
+	}
+	if strings.TrimSpace(p.sessionID) == "" {
+		return errors.New("turn persister: sessionID is empty")
+	}
+	turnID := strings.TrimSpace(t.ID)
+	if turnID == "" {
+		turnID = "turn"
+	}
+	phase := strings.TrimSpace(p.phase)
+	if phase == "" {
+		phase = "final"
+	}
+	payload, err := serde.ToYAML(t, serde.Options{})
+	if err != nil {
+		return errors.Wrap(err, "turn persister: serialize")
+	}
+	inferenceID := ""
+	if v, ok, err := turns.KeyTurnMetaInferenceID.Get(t.Metadata); err == nil && ok {
+		inferenceID = strings.TrimSpace(v)
+	}
+	return p.store.Save(ctx, p.sessionID, p.sessionID, turnID, phase, time.Now().UnixMilli(), string(payload), chatstore.TurnSaveOptions{
+		RuntimeKey:  p.runtimeKey,
+		InferenceID: inferenceID,
+	})
+}
+
+// NewTurnSnapshotHook returns a toolloop snapshot hook that stores intermediate
+// turn states such as pre_inference, post_inference, and post_tools.
+func NewTurnSnapshotHook(sessionID string, runtimeKey string, store chatstore.TurnStore) toolloop.SnapshotHook {
+	if store == nil {
+		return nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	runtimeKey = strings.TrimSpace(runtimeKey)
+	return func(ctx context.Context, t *turns.Turn, phase string) {
+		if t == nil || sessionID == "" {
+			return
+		}
+		turnID := strings.TrimSpace(t.ID)
+		if turnID == "" {
+			turnID = "turn"
+		}
+		inferenceID := ""
+		if v, ok, err := turns.KeyTurnMetaInferenceID.Get(t.Metadata); err == nil && ok {
+			inferenceID = strings.TrimSpace(v)
+		}
+		payload, err := serde.ToYAML(t, serde.Options{})
+		if err != nil {
+			return
+		}
+		_ = store.Save(ctx, sessionID, sessionID, turnID, strings.TrimSpace(phase), time.Now().UnixMilli(), string(payload), chatstore.TurnSaveOptions{
+			RuntimeKey:  runtimeKey,
+			InferenceID: inferenceID,
+		})
+	}
+}

--- a/pkg/chatapp/serverkit/turn_persistence_test.go
+++ b/pkg/chatapp/serverkit/turn_persistence_test.go
@@ -1,0 +1,46 @@
+package serverkit
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/turns"
+)
+
+func TestTurnStorePersisterPersistsFinalTurnYAML(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryTurnStore()
+	turn := &turns.Turn{ID: "turn-1"}
+	turns.AppendBlock(turn, turns.NewUserTextBlock("hello"))
+	p := NewTurnStorePersister(store, "sess-1", "gpt-test", "final")
+	if err := p.PersistTurn(ctx, turn); err != nil {
+		t.Fatalf("PersistTurn: %v", err)
+	}
+	snap, err := store.LoadLatestTurn(ctx, "sess-1", "final")
+	if err != nil {
+		t.Fatalf("LoadLatestTurn: %v", err)
+	}
+	if snap == nil || snap.TurnID != "turn-1" || snap.RuntimeKey != "gpt-test" {
+		t.Fatalf("unexpected snapshot: %#v", snap)
+	}
+	if !strings.Contains(snap.Payload, "hello") {
+		t.Fatalf("payload does not contain turn text: %s", snap.Payload)
+	}
+}
+
+func TestTurnSnapshotHookPersistsIntermediatePhase(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryTurnStore()
+	hook := NewTurnSnapshotHook("sess-1", "gpt-test", store)
+	turn := &turns.Turn{ID: "turn-1"}
+	turns.AppendBlock(turn, turns.NewUserTextBlock("inspect me"))
+	hook(ctx, turn, "post_tools")
+	snap, err := store.LoadLatestTurn(ctx, "sess-1", "post_tools")
+	if err != nil {
+		t.Fatalf("LoadLatestTurn: %v", err)
+	}
+	if snap == nil || snap.Phase != "post_tools" || snap.RuntimeKey != "gpt-test" {
+		t.Fatalf("unexpected snapshot: %#v", snap)
+	}
+}


### PR DESCRIPTION
This change improves the handling and visibility of errors that occur during a
chat's inference runtime.

Key changes:

- **Surface errors in UI**: Adds a timeline projection for `ChatRunFailed`
  events. This surfaces runtime errors as a distinct error message in the chat
  UI, rather than having the generation stop silently.

- **Persist failed turns**: Persists the `Turn` state to the `TurnStore` when a
  run fails. This captures the context at the time of failure, aiding in
  debugging.

- **Generalize turn persistence**: Introduces a new `serverkit` package with
  generic utilities (`TurnStorePersister`, `NewTurnSnapshotHook`) for
  persisting final and intermediate turn states. This provides a structured way
  to save turn snapshots for various phases (e.g., `failed`, `final`,
  `post_tools`).