### PR TITLE
Use published chat-provider 0.2.1

### DIFF
--- a/cmd/web-chat/web/package-lock.json
+++ b/cmd/web-chat/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
-        "@go-go-golems/chat-provider": "^0.1.1",
+        "@go-go-golems/chat-provider": "^0.2.1",
         "@reduxjs/toolkit": "^2.9.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@go-go-golems/chat-provider": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@go-go-golems/chat-provider/-/chat-provider-0.1.1.tgz",
-      "integrity": "sha512-7xN3w/HKVdCV/kUVvI6jL4sNUTXDiFu/UW7unUJq2s7fHBpE5/MnJNFbXR4bqt/7KYXrrNCvK61IeQKL41iDIQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@go-go-golems/chat-provider/-/chat-provider-0.2.1.tgz",
+      "integrity": "sha512-4br5aovzKJST9OggvYNXHK2nwsYXptnJOD24eDk1t2ahhXQVMlm4sj3uKb7dxljmtoWa2O0SjGV8mv7vQ12a5Q==",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.12.0",

--- a/cmd/web-chat/web/package.json
+++ b/cmd/web-chat/web/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@go-go-golems/chat-provider": "^0.1.1",
+    "@go-go-golems/chat-provider": "^0.2.1",
     "@reduxjs/toolkit": "^2.9.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/cmd/web-chat/web/src/features/web-chat/WebChatApp/ProviderStatusbar.tsx
+++ b/cmd/web-chat/web/src/features/web-chat/WebChatApp/ProviderStatusbar.tsx
@@ -1,4 +1,4 @@
-import { selectOverlay, useAppSelector as useChatProviderSelector } from '@go-go-golems/chat-provider';
+import { selectOverlay, useChatSelector } from '@go-go-golems/chat-provider';
 import { ExportMenuForSession } from '../ChatStatusbar/ExportMenu';
 import { fmtShort } from '../format';
 import { getPartProps, mergeClassName, mergeStyle } from '../parts';
@@ -18,7 +18,7 @@ export function ProviderStatusbar(props: StatusbarSlotProps) {
     onToggleErrors,
     partProps,
   } = props;
-  const overlay = useChatProviderSelector(selectOverlay);
+  const overlay = useChatSelector(selectOverlay);
   const statusbarProps = getPartProps('statusbar', partProps);
   const statusbarClassName = mergeClassName(statusbarProps.className);
   const statusbarStyle = mergeStyle(statusbarProps.style);

--- a/cmd/web-chat/web/src/features/web-chat/WebChatApp/WebChatApp.tsx
+++ b/cmd/web-chat/web/src/features/web-chat/WebChatApp/WebChatApp.tsx
@@ -2,7 +2,7 @@ import {
   selectOverlay,
   selectTimelineEntities,
   useChatClient,
-  useAppSelector as useChatProviderSelector,
+  useChatSelector,
 } from '@go-go-golems/chat-provider';
 import type { KeyboardEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -33,8 +33,8 @@ export function WebChatApp({
   onProfileChange,
 }: WebChatAppProps) {
   const client = useChatClient();
-  const overlay = useChatProviderSelector(selectOverlay);
-  const entitiesRaw = useChatProviderSelector(selectTimelineEntities);
+  const overlay = useChatSelector(selectOverlay);
+  const entitiesRaw = useChatSelector(selectTimelineEntities);
   const entities = useMemo(() => entitiesRaw.map(toRenderEntity), [entitiesRaw]);
   const entityCount = entities.length;
   const [text, setText] = useState('');


### PR DESCRIPTION
## Summary

- update Pinocchio web-chat to consume `@go-go-golems/chat-provider@^0.2.1`
- keep the new `useChatSelector` provider hook imports from the chat-provider breaking API cleanup
- update `package-lock.json` to resolve the published registry package instead of the temporary local dist

## Validation

- `cd cmd/web-chat/web && npm run typecheck`
- `cd cmd/web-chat/web && npm test -- --run src/features/web-chat/extensions/pinocchio-timeline-adapters/pinocchioTimelineAdapters.test.ts src/features/web-chat/renderers.test.ts`
- Pinocchio web-chat devctl Playwright smoke passed
