### PR TITLE
Refactor: Update dependencies and adapt to go-go-goja API changes

### DIFF
--- a/cmd/examples/scopedjs-tui-demo/environment.go
+++ b/cmd/examples/scopedjs-tui-demo/environment.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
 	_ "github.com/go-go-golems/go-go-goja/modules/fs"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools/scopedjs"
@@ -156,7 +156,7 @@ func configureDemoRuntime(ctx context.Context, b *scopedjs.Builder, scope demoSc
 	if err := b.AddNativeModule(&obsidianModule{workspaceRoot: scope.WorkspaceRoot}); err != nil {
 		return demoMeta{}, err
 	}
-	if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeContext) error {
+	if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeInitializationContext) error {
 		return ctx.VM.Set("workspaceRoot", scope.WorkspaceRoot)
 	}, scopedjs.GlobalDoc{
 		Type:        "string",
@@ -164,7 +164,7 @@ func configureDemoRuntime(ctx context.Context, b *scopedjs.Builder, scope demoSc
 	}); err != nil {
 		return demoMeta{}, err
 	}
-	if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeContext) error {
+	if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeInitializationContext) error {
 		return ctx.VM.Set("db", buildDBGlobal(scope.Fixtures))
 	}, scopedjs.GlobalDoc{
 		Type:        "object",

--- a/cmd/pinocchio/cmds/js.go
+++ b/cmd/pinocchio/cmds/js.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
 	cmd_sources "github.com/go-go-golems/glazed/pkg/cmds/sources"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	agenttools "github.com/go-go-golems/pinocchio/cmd/agents/simple-chat-agent/pkg/tools"
 	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
 	pjs "github.com/go-go-golems/pinocchio/pkg/js/modules/pinocchio"
@@ -309,7 +309,7 @@ func newPinocchioJSRuntime(ctx context.Context, opts pinocchioJSRuntimeOptions) 
 			filepath.Join(opts.ScriptDir, "node_modules"),
 		),
 	}
-	builder := gojengine.NewBuilder(gojengine.WithRequireOptions(requireOpts...))
+	builder := gojengine.NewRuntimeFactoryBuilder(gojengine.WithRequireOptions(requireOpts...))
 	factory, err := builder.Build()
 	if err != nil {
 		return nil, err
@@ -346,7 +346,7 @@ func newPinocchioJSRuntime(ctx context.Context, opts pinocchioJSRuntimeOptions) 
 	req := reg.Enable(rt.VM)
 	rt.Require = req
 
-	runtimeCtx := &gojengine.RuntimeContext{
+	runtimeCtx := &gojengine.RuntimeInitializationContext{
 		VM:      rt.VM,
 		Require: req,
 		Loop:    rt.Loop,
@@ -354,7 +354,7 @@ func newPinocchioJSRuntime(ctx context.Context, opts pinocchioJSRuntimeOptions) 
 	}
 	if err := (runtimeInitializerFunc{
 		id: "pinocchio-js-helpers",
-		fn: func(_ *gojengine.RuntimeContext) error {
+		fn: func(_ *gojengine.RuntimeInitializationContext) error {
 			installConsole(rt.VM, opts.Stdout, opts.Stderr)
 			installHelpers(rt.VM)
 			return nil
@@ -368,12 +368,12 @@ func newPinocchioJSRuntime(ctx context.Context, opts pinocchioJSRuntimeOptions) 
 
 type runtimeInitializerFunc struct {
 	id string
-	fn func(ctx *gojengine.RuntimeContext) error
+	fn func(ctx *gojengine.RuntimeInitializationContext) error
 }
 
 func (f runtimeInitializerFunc) ID() string { return f.id }
 
-func (f runtimeInitializerFunc) InitRuntime(ctx *gojengine.RuntimeContext) error {
+func (f runtimeInitializerFunc) InitRuntime(ctx *gojengine.RuntimeInitializationContext) error {
 	if f.fn == nil {
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/bobatea v0.1.6
 	github.com/go-go-golems/clay v0.4.11
-	github.com/go-go-golems/geppetto v0.13.1
+	github.com/go-go-golems/geppetto v0.13.2
 	github.com/go-go-golems/glazed v1.3.6
-	github.com/go-go-golems/go-go-goja v0.7.4
+	github.com/go-go-golems/go-go-goja v0.8.0
 	github.com/go-go-golems/logcopter v0.1.0
 	github.com/go-go-golems/sessionstream v0.0.6
 	github.com/go-go-golems/uhoh v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -195,12 +195,12 @@ github.com/go-go-golems/bobatea v0.1.6 h1:6e6WA4RSjqZjys20AvUS3h71+FGSXz09cpbmpk
 github.com/go-go-golems/bobatea v0.1.6/go.mod h1:nF0amRUF8bbssCW/c6wWDDJ49G/YqA3oD5tIwFW0ZdU=
 github.com/go-go-golems/clay v0.4.11 h1:JTzTvL/6/+FCfknrFwPrHZ8d4LQcHX1yF+S250Jg39c=
 github.com/go-go-golems/clay v0.4.11/go.mod h1:Jl1bKnHCgZ0xklhyQfeAQnJiDxfdrHdJ3YzkS5k411k=
-github.com/go-go-golems/geppetto v0.13.1 h1:mmkfX6hFScMNV9TECqB3v3b4pbcrVEZJqH/kDz2Ny2Y=
-github.com/go-go-golems/geppetto v0.13.1/go.mod h1:pyEFYxoLlLCG0R+PLfJMv76jHarD1I7xMod5hW88GBo=
+github.com/go-go-golems/geppetto v0.13.2 h1:EkwrOqYv7FT6Qbmg+CbsMr+oBo4heKNU2kGbhjK2uck=
+github.com/go-go-golems/geppetto v0.13.2/go.mod h1:57iwV3M9+p6RvngwP0h2ElPR8lgSQ8BlUVYYHdrvrmk=
 github.com/go-go-golems/glazed v1.3.6 h1:33jWLP0nE9cDapB8oG/Z6UeqdNszI/OB3OogkhAI808=
 github.com/go-go-golems/glazed v1.3.6/go.mod h1:Q+GuLpSK6OHfDJBbrA4RFOkpYPw++2jj5FAquem8w8g=
-github.com/go-go-golems/go-go-goja v0.7.4 h1:hmnevbBh/3bqG40RI71RBT7QZs6B8t38EZEhjlkcXjM=
-github.com/go-go-golems/go-go-goja v0.7.4/go.mod h1:p8zrYdfGjbBNqi3WHfKxjMzQaXIw+QSyJihn0Abs7TM=
+github.com/go-go-golems/go-go-goja v0.8.0 h1:Cm93aODLyCe8RWC04vjYZKfDDsqJqeRMMIH2P4U/Muk=
+github.com/go-go-golems/go-go-goja v0.8.0/go.mod h1:nBJcgJrQ660gf88vyffcAKpBgXghGMn8KSMuErRt2jg=
 github.com/go-go-golems/logcopter v0.1.0 h1:CGBxAGudhoQOncJ6GEWDJ6c1g5LrU59/ewGlPFKBmdk=
 github.com/go-go-golems/logcopter v0.1.0/go.mod h1:HNCeqsUqxu+Jm5h05YlbN5+KFtK84D5ZnOimvVLyWH4=
 github.com/go-go-golems/sanitize v0.0.2 h1:a1wImzNrhRMyY/1ujqkc7JD2OwdwMxGkMeY4EXwWD/M=


### PR DESCRIPTION
This PR updates the `go-go-goja` and `geppetto` dependencies to their latest
versions and adapts the codebase to breaking changes introduced in `go-go-goja`
v0.8.0.

Key changes include:

- Bumps `go-go-goja` from `v0.7.4` to `v0.8.0`.
- Bumps `geppetto` from `v0.13.1` to `v0.13.2`.
- Renamed `gojengine.RuntimeContext` to
  `gojengine.RuntimeInitializationContext` to reflect its usage during the
  runtime setup phase.
- Renamed the constructor `gojengine.NewBuilder` to
  `gojengine.NewRuntimeFactoryBuilder`.