### PR TITLE
docs: prepare Pinocchio v0.11.6 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased — v0.11.6
+
+### OAuth profile lifecycle
+
+- Added typed `pinocchio.oauth@v1` profiles with redacted status, local logout, and browser Authorization Code + PKCE login.
+- Added locked, atomic, owner-only YAML credential persistence on supported POSIX hosts.
+- Injected Geppetto renewable bearer sources into normal commands and Go-hosted JavaScript engines without copying credentials into inference settings or JavaScript values.
+- Added explicit Claude OAuth profile binding and source precedence over static API keys.
+- Upgraded Geppetto to `v0.13.7` for request-time renewal, bounded pre-stream 401 replay, and credential lifecycle primitives.
+- OAuth YAML persistence now fails closed on Windows before browser or provider interaction; Windows storage remains unsupported.
+
+### Maintenance
+
+- Updated Go dependencies including go-go-goja, sessionstream, Redis, tokenizer, and `golang.org/x` modules.
+- Updated GitHub Actions used by release, security, dependency, lint, and Buf workflows.
+
+### Validation boundary
+
+- Offline tests use synthetic issuers and credentials only. This release does not claim a successful real-provider OAuth login; live smoke remains provider-contract and approval gated.
+
 ## Streamlined Interactive and Chat Mode
 Improved the interactive and chat mode flow by consolidating router management and using RunMode to determine whether to run an initial blocking step. This change makes the interactive mode a special case of chat mode where we first run a blocking step before potentially entering chat mode.
 

--- a/pkg/oauthprofiles/store_test.go
+++ b/pkg/oauthprofiles/store_test.go
@@ -129,6 +129,23 @@ func TestYAMLStoreRequiresCompleteReplacementTuple(t *testing.T) {
 	require.EqualError(t, err, "OAuth credential refresh token is required")
 }
 
+func TestAtomicWriteOwnerOnlyCleansTemporaryFileAfterReplaceFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "profiles.yaml")
+	require.NoError(t, os.Mkdir(target, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "marker"), []byte("keep"), 0o600))
+
+	err := atomicWriteOwnerOnly(target, []byte("replacement"))
+	require.ErrorContains(t, err, "replace OAuth profile registry")
+
+	marker, readErr := os.ReadFile(filepath.Join(target, "marker"))
+	require.NoError(t, readErr)
+	require.Equal(t, "keep", string(marker))
+	temporaryFiles, globErr := filepath.Glob(filepath.Join(dir, ".profiles.yaml.oauth-*"))
+	require.NoError(t, globErr)
+	require.Empty(t, temporaryFiles)
+}
+
 func newTestStore(t *testing.T, path string) *YAMLStore {
 	t.Helper()
 	store, err := NewYAMLStore(

--- a/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/changelog.md
+++ b/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/changelog.md
@@ -113,3 +113,13 @@ Replaced untested Windows OAuth YAML locking/ACL support with an explicit fail-c
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/oauthprofiles/platform_windows.go — Unsupported-platform rejection
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/oauthprofiles/store.go — Early platform validation
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/oauthprofiles/platform_windows_test.go — Windows unsupported-platform contract test
+
+## 2026-07-17
+
+Reconciled completed offline OAuth lifecycle coverage, separated approval-gated live smoke, added failed-write cleanup coverage, and prepared a validated Pinocchio v0.11.6 release handoff without tagging or publishing.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/changelog.md — Release notes
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/oauthprofiles/store_test.go — Persistence failure coverage
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/02-pinocchio-v0-11-6-release-handoff.md — Release checklist

--- a/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/01-implementation-diary.md
+++ b/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/01-implementation-diary.md
@@ -13,6 +13,8 @@ Intent: long-term
 Owners:
     - manuel
 RelatedFiles:
+    - Path: repo://changelog.md
+      Note: v0.11.6 candidate scope and validation boundary
     - Path: repo://cmd/pinocchio/cmds/auth/login.go
       Note: Glazed PKCE loopback browser login implementation
     - Path: repo://cmd/pinocchio/cmds/auth/login_test.go
@@ -41,6 +43,8 @@ RelatedFiles:
       Note: Asserts Windows rejects OAuth YAML store construction
     - Path: repo://pkg/oauthprofiles/store.go
       Note: Enforces platform support at store construction before browser login
+    - Path: repo://ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/02-pinocchio-v0-11-6-release-handoff.md
+      Note: Manual release and verification checklist
     - Path: ws://geppetto/pkg/steps/ai/credentials/oauth/oauth.go
       Note: Observed sibling OAuth primitive
     - Path: ws://pinocchio/lefthook.yml
@@ -52,7 +56,9 @@ RelatedFiles:
     - Path: ws://pinocchio/pkg/oauthprofiles/profile_test.go
       Note: Typed extension and redaction validation coverage
     - Path: ws://pinocchio/pkg/oauthprofiles/store_test.go
-      Note: Credential persistence security and rotation coverage
+      Note: |-
+        Credential persistence security and rotation coverage
+        Failed replacement cleanup and original-target preservation coverage
 ExternalSources:
     - https://github.com/go-go-golems/geppetto/issues/387
 Summary: Chronological investigation and implementation record for Pinocchio profile OAuth lifecycle work.
@@ -60,6 +66,7 @@ LastUpdated: 2026-07-10T23:35:00-04:00
 WhatFor: Continue the profile-backed OAuth, persistence, browser-login, and runtime-source work safely.
 WhenToUse: Use when resuming implementation or reviewing decisions and validation for this ticket.
 ---
+
 
 
 
@@ -1024,3 +1031,77 @@ The rejection had to occur early enough to avoid launching a browser and obtaini
 ### Technical details
 
 The superseded ACL findings were comments `3599576308`, `3599576312`, and `3599576315` on draft PR #186. Follow-up test-boundary comment `3599619596` was addressed by Windows-specific and non-Windows test build tags. Windows fails closed before any credential load, save, delete, browser launch, or provider exchange.
+
+## Step 15: Reconcile offline completion and prepare v0.11.6
+
+PR #186 was merged by the user as `322d07f`. This step reconciles the ticket with the implementation and prepares a manual `v0.11.6` release handoff without creating or pushing a tag. The ticket now distinguishes completed synthetic/offline validation from the separately approval-gated provider contract and live smoke.
+
+Release preparation covers the full delta since `v0.11.5`, not only OAuth. The candidate also contains dependency and GitHub Actions updates, so the release notes and checklist call those out explicitly. A local snapshot and help export succeeded; publication remains a manual user action.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead."
+
+**Assistant interpretation:** Complete ticket bookkeeping and prepare Pinocchio `v0.11.6` for review, but do not tag, publish, or merge on the user’s behalf.
+
+**Inferred user intent:** Produce a trustworthy release-ready handoff after the merged OAuth work while preserving control over irreversible release actions.
+
+### What I did
+
+- Created `chore/pinocchio-oauth-release-prep` from merged `origin/main`.
+- Added a deterministic failed-replacement cleanup test for atomic credential writes.
+- Marked persistence and runtime integration coverage complete using Pinocchio tests plus released Geppetto `v0.13.7` tests.
+- Split offline validation from the approval-gated real-provider smoke task.
+- Added an `Unreleased — v0.11.6` section to the repository changelog.
+- Added `reference/02-pinocchio-v0-11-6-release-handoff.md` with candidate scope, commands, verification, and rollback boundaries.
+- Exported the help database and verified the `oauth-profile-login` section exists.
+- Ran the GoReleaser snapshot dry run.
+
+### Why
+
+The ticket’s remaining checkboxes mixed host integration work with provider/account approval. Separating those concerns prevents a complete offline implementation from claiming unperformed live-provider validation. The release handoff also makes the tag-triggered docs publication path explicit.
+
+### What worked
+
+- `svu current` returned `v0.11.5`; `svu patch` returned `v0.11.6`.
+- Focused OAuth, profile bootstrap, and auth tests passed.
+- The help export produced a valid SQLite database with 56 sections and the `oauth-profile-login` entry.
+- `GOWORK=off make goreleaser` completed a `0.11.6-next` snapshot with archive, DEB, and RPM artifacts.
+
+### What didn't work
+
+No tag or production release was attempted by design. GoReleaser reported existing deprecation warnings for `snapshot.name_template` and `brews`; they did not block the snapshot. The snapshot also reported a dirty tree because release-preparation docs and tests were intentionally uncommitted at that point.
+
+The full repository race baseline remains blocked by the unrelated web-chat/appserver race previously recorded. Focused OAuth race tests passed.
+
+### What I learned
+
+The release workflow publishes docs only after the merged GoReleaser jobs succeed for a `v*` tag. A standalone docs push is unnecessary for this candidate if the release workflow completes normally.
+
+### What was tricky to build
+
+The task list originally bundled synthetic validation and real-provider smoke into one checkbox. It had to be split without weakening the security gate or falsely leaving completed offline work open. Release preparation also had to include dependency/workflow changes merged after `v0.11.5` rather than presenting the release as OAuth-only.
+
+### What warrants a second pair of eyes
+
+- Review `changelog.md` against `git log v0.11.5..HEAD` for release-note completeness.
+- Review the tag and post-publish commands in the release handoff before use.
+- Confirm the unrelated race baseline is acceptable for this patch release.
+- Confirm no documentation claims a real-provider OAuth login.
+
+### What should be done in the future
+
+- Merge the release-preparation PR after review.
+- From a clean updated `main`, manually tag and release `v0.11.6`.
+- Verify GitHub artifacts and docs.yolo publication.
+- Select and document the first provider contract before requesting live-smoke approval.
+
+### Code review instructions
+
+- Start with `changelog.md`, `pkg/oauthprofiles/store_test.go`, `tasks.md`, and `reference/02-pinocchio-v0-11-6-release-handoff.md`.
+- Validate using the commands in the release handoff.
+- Do not run `make tag-patch` or `make release` during review.
+
+### Technical details
+
+Candidate version: `v0.11.6`. Merged OAuth/fail-closed base: `322d07f3cbe09c1d6bc78990d3a037aad09f2f36`. Help export: `/tmp/pinocchio-docs-export/help.sqlite`. Snapshot log: `/tmp/pinocchio-v0116-release-dry-run.log`.

--- a/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/02-pinocchio-v0-11-6-release-handoff.md
+++ b/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/reference/02-pinocchio-v0-11-6-release-handoff.md
@@ -1,0 +1,123 @@
+---
+Title: Pinocchio v0.11.6 release handoff
+Ticket: PINOCCHIO-OAUTH-PROFILE-LIFECYCLE
+Status: active
+Topics:
+    - pinocchio
+    - oauth
+    - credentials
+    - profiles
+    - security
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: repo://.github/workflows/release.yml
+      Note: Tag-triggered artifacts and docs publication
+    - Path: repo://.goreleaser.yaml
+      Note: Snapshot and production artifact configuration
+    - Path: repo://changelog.md
+      Note: v0.11.6 release scope and validation boundary
+    - Path: repo://pkg/doc/topics/oauth-profile-login.md
+      Note: OAuth operator help exported to docs.yolo
+    - Path: repo://pkg/oauthprofiles/store.go
+      Note: POSIX credential persistence and Windows fail-closed boundary
+ExternalSources: []
+Summary: Validated release candidate scope, dry-run results, and manual tag/publish checklist for Pinocchio v0.11.6.
+LastUpdated: 2026-07-17T11:28:36.612631046-04:00
+WhatFor: Prepare and manually publish Pinocchio v0.11.6 after the OAuth lifecycle and dependency updates.
+WhenToUse: Use before tagging v0.11.6 and while verifying its GitHub release and docs.yolo publication.
+---
+
+
+# Pinocchio v0.11.6 release handoff
+
+## Goal
+
+Provide a reviewable, copy/paste-ready handoff for publishing Pinocchio `v0.11.6` without conflating offline OAuth lifecycle validation with a real-provider login claim.
+
+## Candidate scope
+
+The candidate is the first patch release after `v0.11.5`. It includes:
+
+- profile-backed OAuth login, status, logout, redaction, and POSIX YAML persistence;
+- Geppetto `v0.13.7` renewable bearer integration for normal commands and Go-hosted JavaScript engines;
+- Claude OAuth profile binding and static-key/source conflict enforcement;
+- explicit fail-closed Windows behavior for OAuth YAML persistence;
+- dependency updates for go-go-goja, sessionstream, Redis, tokenizer, and `golang.org/x` modules;
+- GitHub Actions version updates.
+
+The release does **not** claim a real-provider OAuth smoke. Provider selection, exact redirect registration, scopes, public-client policy, refresh semantics, account selection, and live smoke remain separately approval-gated.
+
+## Validation completed during preparation
+
+- `svu current` returned `v0.11.5`; `svu patch` returned `v0.11.6`.
+- Focused OAuth/profile/auth tests passed under `GOWORK=off`.
+- The merged PR series passed repository tests, lint, GoSec, govulncheck, dependency review, secret scanning, and CodeQL.
+- `GOWORK=off make goreleaser` produced a `0.11.6-next` Linux snapshot, archive, DEB, and RPM.
+- Help export produced a valid SQLite database containing `oauth-profile-login`.
+- Windows OAuth persistence is intentionally unsupported; Windows-target test packages compile and contain an unsupported-platform assertion.
+
+The known repository-wide race baseline in web-chat/appserver remains unrelated to OAuth. Focused OAuth race tests pass.
+
+## Manual release checklist
+
+Run only after the release-preparation PR is merged and local `main` is clean:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git status --short
+svu current
+svu patch
+GOWORK=off go test ./... -count=1
+GOWORK=off make lint logcopter-check gosec govulncheck
+rm -rf /tmp/pinocchio-docs-export
+mkdir -p /tmp/pinocchio-docs-export
+GOWORK=off go run ./cmd/pinocchio help export \
+  --format sqlite \
+  --output-path /tmp/pinocchio-docs-export/help.sqlite
+sqlite3 /tmp/pinocchio-docs-export/help.sqlite \
+  "SELECT slug,title FROM sections WHERE slug = 'oauth-profile-login';"
+GOWORK=off make goreleaser
+```
+
+Expected version before tagging: `v0.11.6`.
+
+Tag and publish are intentionally manual:
+
+```bash
+make tag-patch
+git show --no-patch v0.11.6
+make release
+```
+
+`make release` pushes tags and verifies module proxy resolution. The tag-triggered release workflow builds Linux and Darwin artifacts, signs checksums, publishes packages/Homebrew metadata, and then publishes the Pinocchio help database to docs.yolo.
+
+## Post-publish verification
+
+```bash
+gh run list --workflow release.yml --limit 5
+gh release view v0.11.6
+curl -fsSL https://docs.yolo.scapegoat.dev/api/packages
+```
+
+Verify that:
+
+1. the `v0.11.6` GitHub release and checksums exist;
+2. Linux and Darwin artifacts are present;
+3. the release workflow’s `publish-docs` job succeeded;
+4. docs.yolo lists Pinocchio `v0.11.6`;
+5. the OAuth help page is discoverable without exposing credential values.
+
+## Rollback boundary
+
+Do not move or reuse the tag if publication partially fails. Preserve the immutable tag, diagnose the failed workflow/job, and rerun the supported release continuation or publish job. Do not add a live credential test to release automation.
+
+## Related
+
+- `pkg/doc/topics/oauth-profile-login.md`
+- `pkg/oauthprofiles/store.go`
+- `.github/workflows/release.yml`
+- `.goreleaser.yaml`
+- `changelog.md`

--- a/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/tasks.md
+++ b/ttmp/2026/07/10/PINOCCHIO-OAUTH-PROFILE-LIFECYCLE--profile-backed-oauth-credentials-and-browser-login/tasks.md
@@ -20,14 +20,14 @@
 - [x] Implement explicit writable local registry selection and owner-only permission validation <!-- t:p2a1 -->
 - [x] Implement locked read/patch/write with temporary `0600` file, fsync, rename, and cleanup <!-- t:p2a2 -->
 - [x] Implement Geppetto `credentials.Store` with provider/base-URL identity checks <!-- t:p2a3 -->
-- [ ] Test tuple rotation, concurrent saves, failed writes, unsafe permissions, and unrelated-profile preservation <!-- t:p2a4 -->
+- [x] Test tuple rotation, concurrent saves, failed writes, unsafe permissions, and unrelated-profile preservation <!-- t:p2a4 -->
 
 ## Phase 3 — Runtime credential source integration
 
 - [x] Bind typed profile config to Geppetto `credentials/oauth.Client` and a `credentials.Refresher` adapter <!-- t:p3a1 -->
 - [x] Build/inject `RenewableBearerTokenSource` through the Pinocchio source-aware engine factory <!-- t:p3a2 -->
 - [x] Ensure OAuth profiles never pass refresh material through `InferenceSettings.APIKeys` <!-- t:p3a3 -->
-- [ ] Test proactive refresh, source precedence, first-401 replay, second-401 stop, and redaction <!-- t:p3a4 -->
+- [x] Test proactive refresh, source precedence, first-401 replay, second-401 stop, and redaction <!-- t:p3a4 -->
 
 ## Phase 4 — Browser login command
 
@@ -39,5 +39,6 @@
 ## Phase 5 — Operations, validation, and delivery
 
 - [x] Document permissions, backup/recovery, revoke/re-login, migration, and plaintext-at-rest tradeoffs <!-- t:p5a1 -->
-- [ ] Run focused/full/race/lint/logcopter/security validation and a secret-safe real-provider smoke <!-- t:p5a2 -->
-- [ ] Relate files, update diary/changelog, run `docmgr doctor`, and deliver an updated review bundle <!-- t:p5a3 -->
+- [x] Run focused/full/race/lint/logcopter/security validation with synthetic providers <!-- t:p5a2 -->
+- [ ] Run a secret-safe real-provider smoke only after provider-contract and account approval <!-- t:6ruj -->
+- [x] Relate files, update diary/changelog, run docmgr doctor, and prepare the v0.11.6 review handoff <!-- t:p5a3 -->


### PR DESCRIPTION
## Summary

- add `v0.11.6` release notes covering OAuth lifecycle, Windows fail-closed behavior, dependency updates, and the live-smoke boundary
- add deterministic atomic-write replacement-failure cleanup coverage
- reconcile completed offline ticket tasks while keeping provider selection and live smoke open/approval-gated
- add a manual release handoff with validation, tag, docs publication, verification, and rollback commands

## Validation

- `svu current` → `v0.11.5`; `svu patch` → `v0.11.6`
- focused OAuth/profile/auth tests pass
- pre-commit full tests and lint pass
- `GOWORK=off make goreleaser` produced a `0.11.6-next` snapshot, archive, DEB, and RPM
- help export produced valid SQLite with `oauth-profile-login`
- `docmgr doctor --ticket PINOCCHIO-OAUTH-PROFILE-LIFECYCLE --stale-after 30` passes

## Boundaries

- no tag or release was created
- no live provider smoke was run
- release and merge remain manual user actions
