### PR TITLE
feat(cli): Add `profiles debug` command

### DIFF
--- a/cmd/pinocchio/cmds/profiles/debug.go
+++ b/cmd/pinocchio/cmds/profiles/debug.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
+	"github.com/pkg/errors"
 )
 
 // DebugCommand reports the source, stack, and final settings selected for a
@@ -39,7 +40,7 @@ func NewDebugCommand() (*DebugCommand, error) {
 	if err != nil {
 		return nil, err
 	}
-	profileSettingsSection, err := geppettosections.NewProfileSettingsSection()
+	geppettoSections, err := geppettosections.CreateGeppettoSections()
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ Examples:
 					fields.WithHelp("Include redacted settings JSON for each resolution stage"),
 				),
 			),
-			cmds.WithSections(commandSettingsSection, profileSettingsSection),
+			cmds.WithSections(append([]schema.Section{commandSettingsSection}, geppettoSections...)...),
 		),
 	}, nil
 }
@@ -80,13 +81,13 @@ func (c *DebugCommand) RunIntoGlazeProcessor(
 	settings := &DebugSettings{}
 	if parsedLayers != nil {
 		if err := parsedLayers.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
-			return fmt.Errorf("decode profiles debug settings: %w", err)
+			return errors.Wrap(err, "decode profiles debug settings")
 		}
 	}
 
 	resolved, err := profilebootstrap.ResolveCLIEngineSettings(ctx, parsedLayers)
 	if err != nil {
-		return fmt.Errorf("resolve profile engine settings: %w", err)
+		return errors.Wrap(err, "resolve profile engine settings")
 	}
 	if resolved != nil && resolved.Close != nil {
 		defer resolved.Close()
@@ -95,7 +96,7 @@ func (c *DebugCommand) RunIntoGlazeProcessor(
 		return fmt.Errorf("no profile registry configured")
 	}
 
-	for _, source := range debugSourceRows(resolved.ProfileRuntime.ProfileSettings.ProfileRegistries) {
+	for _, source := range debugSourceRows(resolved.ProfileRuntime) {
 		if err := gp.AddRow(ctx, source); err != nil {
 			return err
 		}
@@ -109,9 +110,10 @@ func (c *DebugCommand) RunIntoGlazeProcessor(
 	for _, lineage := range profile.StackLineage {
 		layer, err := registry.GetEngineProfile(ctx, lineage.RegistrySlug, lineage.EngineProfileSlug)
 		if err != nil {
-			return fmt.Errorf("load profile-stack layer %s/%s: %w", lineage.RegistrySlug, lineage.EngineProfileSlug, err)
+			return errors.Wrapf(err, "load profile-stack layer %s/%s", lineage.RegistrySlug, lineage.EngineProfileSlug)
 		}
-		if err := gp.AddRow(ctx, debugSettingsRow("profile-layer", lineage.RegistrySlug.String(), lineage.EngineProfileSlug.String(), layer.InferenceSettings, settings.IncludeSettings)); err != nil {
+		row := debugProfileLayerRow(lineage, layer.InferenceSettings, settings.IncludeSettings)
+		if err := gp.AddRow(ctx, row); err != nil {
 			return err
 		}
 	}
@@ -125,7 +127,8 @@ func (c *DebugCommand) RunIntoGlazeProcessor(
 	return gp.AddRow(ctx, debugSettingsRow("final", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), resolved.FinalInferenceSettings, settings.IncludeSettings))
 }
 
-func debugSourceRows(entries []string) []types.Row {
+func debugSourceRows(runtime *profilebootstrap.ResolvedCLIProfileRuntime) []types.Row {
+	entries := runtime.ProfileSettings.ProfileRegistries
 	specs, err := gepprofiles.ParseRegistrySourceSpecs(entries)
 	if err != nil {
 		return []types.Row{types.NewRow(
@@ -149,7 +152,30 @@ func debugSourceRows(entries []string) []types.Row {
 		}
 		rows = append(rows, row)
 	}
+	if runtime.Documents != nil {
+		for _, file := range runtime.Documents.Files {
+			rows = append(rows, types.NewRow(
+				types.MRP("stage", "source"),
+				types.MRP("source_kind", "config-document"),
+				types.MRP("source", file.Path),
+				types.MRP("source_path", file.Path),
+				types.MRP("source_layer", string(file.Layer)),
+				types.MRP("source_name", file.SourceName),
+			))
+		}
+	}
 	return rows
+}
+
+func debugProfileLayerRow(lineage gepprofiles.ResolvedProfileStackEntry, settings any, includeSettings bool) types.Row {
+	row := debugSettingsRow("profile-layer", lineage.RegistrySlug.String(), lineage.EngineProfileSlug.String(), settings, includeSettings)
+	if lineage.Source != "" {
+		row.Set("source", lineage.Source)
+	}
+	if lineage.Version != 0 {
+		row.Set("version", lineage.Version)
+	}
+	return row
 }
 
 func debugSettingsRow(stage, registry, profile string, settings any, includeSettings bool) types.Row {

--- a/cmd/pinocchio/cmds/profiles/debug.go
+++ b/cmd/pinocchio/cmds/profiles/debug.go
@@ -1,0 +1,238 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
+	geppettosections "github.com/go-go-golems/geppetto/pkg/sections"
+	aistepssettings "github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/types"
+	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
+)
+
+// DebugCommand reports the source, stack, and final settings selected for a
+// Pinocchio engine profile. It intentionally reports credential presence only;
+// it never emits credential values.
+type DebugCommand struct {
+	*cmds.CommandDescription
+}
+
+// DebugSettings controls the safe settings detail included by profiles debug.
+type DebugSettings struct {
+	IncludeSettings bool `glazed:"include-settings"`
+}
+
+var _ cmds.GlazeCommand = (*DebugCommand)(nil)
+
+// NewDebugCommand creates the profile-resolution diagnostic command.
+func NewDebugCommand() (*DebugCommand, error) {
+	commandSettingsSection, err := cli.NewCommandSettingsSection()
+	if err != nil {
+		return nil, err
+	}
+	profileSettingsSection, err := geppettosections.NewProfileSettingsSection()
+	if err != nil {
+		return nil, err
+	}
+
+	return &DebugCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"debug",
+			cmds.WithShort("Debug profile sources, stacking, and effective credential presence"),
+			cmds.WithLong(`Resolve the selected Pinocchio profile exactly as a runtime does.
+
+The command reports registry sources, profile-stack order, and the base, stack-merged,
+and final effective settings. Credential values are never printed: each API-key field is
+reported only as present or empty.
+
+Examples:
+  pinocchio profiles debug --profile researcher
+  pinocchio profiles debug --profile-registries ~/.config/pinocchio/profiles.yaml,./profiles.yaml --profile ttc-live-luna-codex
+  pinocchio profiles debug --profile assistant --include-settings --format json
+`),
+			cmds.WithFlags(
+				fields.New(
+					"include-settings",
+					fields.TypeBool,
+					fields.WithDefault(false),
+					fields.WithHelp("Include redacted settings JSON for each resolution stage"),
+				),
+			),
+			cmds.WithSections(commandSettingsSection, profileSettingsSection),
+		),
+	}, nil
+}
+
+func (c *DebugCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *values.Values,
+	gp middlewares.Processor,
+) error {
+	settings := &DebugSettings{}
+	if parsedLayers != nil {
+		if err := parsedLayers.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
+			return fmt.Errorf("decode profiles debug settings: %w", err)
+		}
+	}
+
+	resolved, err := profilebootstrap.ResolveCLIEngineSettings(ctx, parsedLayers)
+	if err != nil {
+		return fmt.Errorf("resolve profile engine settings: %w", err)
+	}
+	if resolved != nil && resolved.Close != nil {
+		defer resolved.Close()
+	}
+	if resolved == nil || resolved.ProfileRuntime == nil || resolved.ProfileRuntime.ProfileRegistryChain == nil || resolved.ProfileRuntime.ProfileRegistryChain.Registry == nil {
+		return fmt.Errorf("no profile registry configured")
+	}
+
+	for _, source := range debugSourceRows(resolved.ProfileRuntime.ProfileSettings.ProfileRegistries) {
+		if err := gp.AddRow(ctx, source); err != nil {
+			return err
+		}
+	}
+
+	profile := resolved.ResolvedEngineProfile
+	if profile == nil {
+		return fmt.Errorf("selected profile did not resolve")
+	}
+	registry := resolved.ProfileRuntime.ProfileRegistryChain.Registry
+	for _, lineage := range profile.StackLineage {
+		layer, err := registry.GetEngineProfile(ctx, lineage.RegistrySlug, lineage.EngineProfileSlug)
+		if err != nil {
+			return fmt.Errorf("load profile-stack layer %s/%s: %w", lineage.RegistrySlug, lineage.EngineProfileSlug, err)
+		}
+		if err := gp.AddRow(ctx, debugSettingsRow("profile-layer", lineage.RegistrySlug.String(), lineage.EngineProfileSlug.String(), layer.InferenceSettings, settings.IncludeSettings)); err != nil {
+			return err
+		}
+	}
+
+	if err := gp.AddRow(ctx, debugSettingsRow("profile-stack-effective", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), profile.InferenceSettings, settings.IncludeSettings)); err != nil {
+		return err
+	}
+	if err := gp.AddRow(ctx, debugSettingsRow("base", "", "", resolved.BaseInferenceSettings, settings.IncludeSettings)); err != nil {
+		return err
+	}
+	return gp.AddRow(ctx, debugSettingsRow("final", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), resolved.FinalInferenceSettings, settings.IncludeSettings))
+}
+
+func debugSourceRows(entries []string) []types.Row {
+	specs, err := gepprofiles.ParseRegistrySourceSpecs(entries)
+	if err != nil {
+		return []types.Row{types.NewRow(
+			types.MRP("stage", "source-error"),
+			types.MRP("source_error", err.Error()),
+		)}
+	}
+	rows := make([]types.Row, 0, len(specs))
+	for _, spec := range specs {
+		row := types.NewRow(
+			types.MRP("stage", "source"),
+			types.MRP("source_kind", string(spec.Kind)),
+		)
+		if spec.Kind == gepprofiles.RegistrySourceKindSQLiteDSN {
+			row.Set("source", "sqlite-dsn:***REDACTED***")
+		} else {
+			row.Set("source", spec.Raw)
+		}
+		if spec.Path != "" {
+			row.Set("source_path", spec.Path)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func debugSettingsRow(stage, registry, profile string, settings any, includeSettings bool) types.Row {
+	row := types.NewRow(types.MRP("stage", stage))
+	if registry != "" {
+		row.Set("registry", registry)
+	}
+	if profile != "" {
+		row.Set("profile", profile)
+	}
+
+	summary, ok := settingsSummaryForDebug(settings)
+	if !ok {
+		row.Set("api_key_status", []string{"none"})
+		return row
+	}
+	row.Set("api_key_status", apiKeyStatus(summary.APIKeys))
+	row.Set("chat_engine", summary.ChatEngine)
+	row.Set("chat_api_type", summary.ChatAPIType)
+	row.Set("embedding_type", summary.EmbeddingType)
+	row.Set("embedding_engine", summary.EmbeddingEngine)
+	row.Set("embedding_dimensions", summary.EmbeddingDimensions)
+	if includeSettings {
+		row.Set("settings_json", summary.SettingsJSON)
+	}
+	return row
+}
+
+type debugSettingsSummary struct {
+	APIKeys             map[string]string
+	ChatEngine          string
+	ChatAPIType         string
+	EmbeddingType       string
+	EmbeddingEngine     string
+	EmbeddingDimensions int
+	SettingsJSON        string
+}
+
+func settingsSummaryForDebug(raw any) (debugSettingsSummary, bool) {
+	settings, ok := raw.(*aistepssettings.InferenceSettings)
+	if !ok || settings == nil {
+		return debugSettingsSummary{}, false
+	}
+
+	summary := debugSettingsSummary{APIKeys: map[string]string{}}
+	if settings.API != nil {
+		for name, value := range settings.API.APIKeys {
+			summary.APIKeys[name] = value
+		}
+	}
+	if settings.Chat != nil {
+		if settings.Chat.Engine != nil {
+			summary.ChatEngine = *settings.Chat.Engine
+		}
+		if settings.Chat.ApiType != nil {
+			summary.ChatAPIType = string(*settings.Chat.ApiType)
+		}
+	}
+	if settings.Embeddings != nil {
+		summary.EmbeddingType = settings.Embeddings.Type
+		summary.EmbeddingEngine = settings.Embeddings.Engine
+		summary.EmbeddingDimensions = settings.Embeddings.Dimensions
+	}
+	summary.SettingsJSON = summarizeSettings(settings).SettingsJSON
+	return summary, true
+}
+
+func apiKeyStatus(keys map[string]string) []string {
+	if len(keys) == 0 {
+		return []string{"none"}
+	}
+	names := make([]string, 0, len(keys))
+	for name := range keys {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	statuses := make([]string, 0, len(names))
+	for _, name := range names {
+		status := "empty"
+		if strings.TrimSpace(keys[name]) != "" {
+			status = "present"
+		}
+		statuses = append(statuses, name+"="+status)
+	}
+	return statuses
+}

--- a/cmd/pinocchio/cmds/profiles/debug.go
+++ b/cmd/pinocchio/cmds/profiles/debug.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
+	"github.com/go-go-golems/pinocchio/pkg/oauthprofiles"
 	"github.com/pkg/errors"
 )
 
@@ -118,13 +119,26 @@ func (c *DebugCommand) RunIntoGlazeProcessor(
 		}
 	}
 
-	if err := gp.AddRow(ctx, debugSettingsRow("profile-stack-effective", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), profile.InferenceSettings, settings.IncludeSettings)); err != nil {
+	selectedProfile, err := registry.GetEngineProfile(ctx, profile.RegistrySlug, profile.EngineProfileSlug)
+	if err != nil {
+		return errors.Wrapf(err, "load selected profile %s/%s", profile.RegistrySlug, profile.EngineProfileSlug)
+	}
+	oauthProfile, err := oauthprofiles.Parse(selectedProfile.Extensions)
+	if err != nil {
+		return errors.Wrap(err, "parse selected profile OAuth credentials")
+	}
+
+	stackEffectiveRow := debugSettingsRow("profile-stack-effective", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), profile.InferenceSettings, settings.IncludeSettings)
+	addOAuthCredentialStatus(stackEffectiveRow, oauthProfile)
+	if err := gp.AddRow(ctx, stackEffectiveRow); err != nil {
 		return err
 	}
 	if err := gp.AddRow(ctx, debugSettingsRow("base", "", "", resolved.BaseInferenceSettings, settings.IncludeSettings)); err != nil {
 		return err
 	}
-	return gp.AddRow(ctx, debugSettingsRow("final", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), resolved.FinalInferenceSettings, settings.IncludeSettings))
+	finalRow := debugSettingsRow("final", profile.RegistrySlug.String(), profile.EngineProfileSlug.String(), resolved.FinalInferenceSettings, settings.IncludeSettings)
+	addOAuthCredentialStatus(finalRow, oauthProfile)
+	return gp.AddRow(ctx, finalRow)
 }
 
 func debugSourceRows(runtime *profilebootstrap.ResolvedCLIProfileRuntime) []types.Row {
@@ -165,6 +179,23 @@ func debugSourceRows(runtime *profilebootstrap.ResolvedCLIProfileRuntime) []type
 		}
 	}
 	return rows
+}
+
+func addOAuthCredentialStatus(row types.Row, profile *oauthprofiles.Profile) {
+	if row == nil || profile == nil {
+		return
+	}
+	row.Set("oauth_credential_status", []string{
+		"access_token=" + credentialValueStatus(profile.Credential.AccessToken),
+		"refresh_token=" + credentialValueStatus(profile.Credential.RefreshToken),
+	})
+}
+
+func credentialValueStatus(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "empty"
+	}
+	return "present"
 }
 
 func debugProfileLayerRow(lineage gepprofiles.ResolvedProfileStackEntry, settings any, includeSettings bool) types.Row {

--- a/cmd/pinocchio/cmds/profiles/debug_test.go
+++ b/cmd/pinocchio/cmds/profiles/debug_test.go
@@ -1,0 +1,142 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	geppettosections "github.com/go-go-golems/geppetto/pkg/sections"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/glazed/pkg/types"
+)
+
+func TestDebugCommandShowsStackAndRedactsCredentialValues(t *testing.T) {
+	registryPath := writeRegistry(t, `slug: workspace
+profiles:
+  openai-base:
+    slug: openai-base
+    inference_settings:
+      api:
+        api_keys:
+          openai-api-key: test-openai-key-must-not-appear
+  embedding-small:
+    slug: embedding-small
+    stack:
+      - profile_slug: openai-base
+    inference_settings:
+      embeddings:
+        type: openai
+        engine: text-embedding-3-small
+        dimensions: 1536
+  assistant:
+    slug: assistant
+    stack:
+      - profile_slug: embedding-small
+    inference_settings:
+      chat:
+        api_type: openai-responses
+        engine: gpt-5
+`)
+
+	cmd, err := NewDebugCommand()
+	if err != nil {
+		t.Fatalf("NewDebugCommand: %v", err)
+	}
+	processor := &captureProcessor{}
+	if err := cmd.RunIntoGlazeProcessor(context.Background(), parsedDebugValues(t, registryPath, "assistant", true), processor); err != nil {
+		t.Fatalf("RunIntoGlazeProcessor: %v", err)
+	}
+
+	baseLayer := findDebugRow(t, processor.rows, "profile-layer", "openai-base")
+	assertStringSliceCellContains(t, baseLayer, "api_key_status", "openai-api-key=present")
+	final := findDebugRow(t, processor.rows, "final", "assistant")
+	assertStringSliceCellContains(t, final, "api_key_status", "openai-api-key=present")
+	assertCell(t, final, "embedding_type", "openai")
+	assertCell(t, final, "embedding_engine", "text-embedding-3-small")
+	assertCell(t, final, "embedding_dimensions", 1536)
+
+	encoded, err := json.Marshal(processor.rows)
+	if err != nil {
+		t.Fatalf("marshal debug output: %v", err)
+	}
+	if strings.Contains(string(encoded), "test-openai-key-must-not-appear") {
+		t.Fatalf("debug output leaked an API key: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), "***REDACTED***") {
+		t.Fatalf("expected --include-settings to contain a redaction marker, got %s", encoded)
+	}
+}
+
+func parsedDebugValues(t *testing.T, registryPath, profile string, includeSettings bool) *values.Values {
+	t.Helper()
+	cmd, err := NewDebugCommand()
+	if err != nil {
+		t.Fatalf("NewDebugCommand: %v", err)
+	}
+	parsed := values.New()
+	defaultSection, ok := cmd.GetDefaultSection()
+	if !ok {
+		t.Fatal("missing default section")
+	}
+	defaultValues, err := values.NewSectionValues(defaultSection)
+	if err != nil {
+		t.Fatalf("default values: %v", err)
+	}
+	if err := values.WithFieldValue("include-settings", includeSettings)(defaultValues); err != nil {
+		t.Fatalf("set include-settings: %v", err)
+	}
+	parsed.Set(values.DefaultSlug, defaultValues)
+
+	profileSection, err := geppettosections.NewProfileSettingsSection()
+	if err != nil {
+		t.Fatalf("profile section: %v", err)
+	}
+	profileValues, err := values.NewSectionValues(profileSection)
+	if err != nil {
+		t.Fatalf("profile values: %v", err)
+	}
+	if err := values.WithFieldValue("profile-registries", []string{registryPath})(profileValues); err != nil {
+		t.Fatalf("set profile registries: %v", err)
+	}
+	if err := values.WithFieldValue("profile", profile)(profileValues); err != nil {
+		t.Fatalf("set profile: %v", err)
+	}
+	parsed.Set(geppettosections.ProfileSettingsSectionSlug, profileValues)
+	return parsed
+}
+
+func findDebugRow(t *testing.T, rows []types.Row, stage, profile string) types.Row {
+	t.Helper()
+	for _, row := range rows {
+		if cellString(t, row, "stage") == stage && cellString(t, row, "profile") == profile {
+			return row
+		}
+	}
+	t.Fatalf("debug row stage=%q profile=%q not found in %#v", stage, profile, rows)
+	return nil
+}
+
+func assertStringSliceCellContains(t *testing.T, row types.Row, key, want string) {
+	t.Helper()
+	got, ok := row.Get(types.FieldName(key))
+	if !ok {
+		t.Fatalf("missing cell %q", key)
+	}
+	values, ok := got.([]string)
+	if !ok {
+		t.Fatalf("cell %q: expected []string, got %T (%#v)", key, got, got)
+	}
+	if !containsString(values, want) {
+		t.Fatalf("cell %q: expected %#v to contain %q", key, values, want)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/pinocchio/cmds/profiles/debug_test.go
+++ b/cmd/pinocchio/cmds/profiles/debug_test.go
@@ -3,12 +3,18 @@ package profiles
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
+	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
 	geppettosections "github.com/go-go-golems/geppetto/pkg/sections"
+	openaisettings "github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	glazedconfig "github.com/go-go-golems/glazed/pkg/config"
 	"github.com/go-go-golems/glazed/pkg/types"
+	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
+	"github.com/go-go-golems/pinocchio/pkg/configdoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDebugCommandShowsStackAndRedactsCredentialValues(t *testing.T) {
@@ -40,16 +46,14 @@ profiles:
 `)
 
 	cmd, err := NewDebugCommand()
-	if err != nil {
-		t.Fatalf("NewDebugCommand: %v", err)
-	}
+	require.NoError(t, err)
 	processor := &captureProcessor{}
-	if err := cmd.RunIntoGlazeProcessor(context.Background(), parsedDebugValues(t, registryPath, "assistant", true), processor); err != nil {
-		t.Fatalf("RunIntoGlazeProcessor: %v", err)
-	}
+	require.NoError(t, cmd.RunIntoGlazeProcessor(context.Background(), parsedDebugValues(t, registryPath, "assistant", true), processor))
 
 	baseLayer := findDebugRow(t, processor.rows, "profile-layer", "openai-base")
 	assertStringSliceCellContains(t, baseLayer, "api_key_status", "openai-api-key=present")
+	base := findDebugRow(t, processor.rows, "base", "")
+	assertStringSliceCellContains(t, base, "api_key_status", "openai-api-key=present")
 	final := findDebugRow(t, processor.rows, "final", "assistant")
 	assertStringSliceCellContains(t, final, "api_key_status", "openai-api-key=present")
 	assertCell(t, final, "embedding_type", "openai")
@@ -57,52 +61,66 @@ profiles:
 	assertCell(t, final, "embedding_dimensions", 1536)
 
 	encoded, err := json.Marshal(processor.rows)
-	if err != nil {
-		t.Fatalf("marshal debug output: %v", err)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "test-openai-key-must-not-appear", "debug output leaked a profile API key")
+	assert.NotContains(t, string(encoded), "base-openai-key-must-not-appear", "debug output leaked a base API key")
+	assert.Contains(t, string(encoded), "***REDACTED***", "expected --include-settings to contain a redaction marker")
+}
+
+func TestDebugProfileLayerRowIncludesLineageProvenance(t *testing.T) {
+	row := debugProfileLayerRow(gepprofiles.ResolvedProfileStackEntry{
+		RegistrySlug:      gepprofiles.MustRegistrySlug("workspace"),
+		EngineProfileSlug: gepprofiles.MustEngineProfileSlug("assistant"),
+		Source:            "/profiles/workspace.yaml",
+		Version:           42,
+	}, nil, false)
+
+	assertCell(t, row, "source", "/profiles/workspace.yaml")
+	assertCell(t, row, "version", uint64(42))
+}
+
+func TestDebugSourceRowsIncludeConfigDocuments(t *testing.T) {
+	runtime := &profilebootstrap.ResolvedCLIProfileRuntime{
+		Documents: &configdoc.ResolvedDocuments{Files: []glazedconfig.ResolvedConfigFile{{
+			Path:       "/workspace/.pinocchio.yml",
+			Layer:      glazedconfig.LayerCWD,
+			SourceName: "cwd-local-profile",
+		}}},
 	}
-	if strings.Contains(string(encoded), "test-openai-key-must-not-appear") {
-		t.Fatalf("debug output leaked an API key: %s", encoded)
-	}
-	if !strings.Contains(string(encoded), "***REDACTED***") {
-		t.Fatalf("expected --include-settings to contain a redaction marker, got %s", encoded)
-	}
+
+	rows := debugSourceRows(runtime)
+	require.Len(t, rows, 1)
+	assertCell(t, rows[0], "source_kind", "config-document")
+	assertCell(t, rows[0], "source_path", "/workspace/.pinocchio.yml")
+	assertCell(t, rows[0], "source_name", "cwd-local-profile")
 }
 
 func parsedDebugValues(t *testing.T, registryPath, profile string, includeSettings bool) *values.Values {
 	t.Helper()
 	cmd, err := NewDebugCommand()
-	if err != nil {
-		t.Fatalf("NewDebugCommand: %v", err)
-	}
+	require.NoError(t, err)
 	parsed := values.New()
 	defaultSection, ok := cmd.GetDefaultSection()
-	if !ok {
-		t.Fatal("missing default section")
-	}
+	require.True(t, ok, "missing default section")
 	defaultValues, err := values.NewSectionValues(defaultSection)
-	if err != nil {
-		t.Fatalf("default values: %v", err)
-	}
-	if err := values.WithFieldValue("include-settings", includeSettings)(defaultValues); err != nil {
-		t.Fatalf("set include-settings: %v", err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, values.WithFieldValue("include-settings", includeSettings)(defaultValues))
 	parsed.Set(values.DefaultSlug, defaultValues)
 
 	profileSection, err := geppettosections.NewProfileSettingsSection()
-	if err != nil {
-		t.Fatalf("profile section: %v", err)
-	}
+	require.NoError(t, err)
 	profileValues, err := values.NewSectionValues(profileSection)
-	if err != nil {
-		t.Fatalf("profile values: %v", err)
-	}
-	if err := values.WithFieldValue("profile-registries", []string{registryPath})(profileValues); err != nil {
-		t.Fatalf("set profile registries: %v", err)
-	}
-	if err := values.WithFieldValue("profile", profile)(profileValues); err != nil {
-		t.Fatalf("set profile: %v", err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, values.WithFieldValue("profile-registries", []string{registryPath})(profileValues))
+	require.NoError(t, values.WithFieldValue("profile", profile)(profileValues))
 	parsed.Set(geppettosections.ProfileSettingsSectionSlug, profileValues)
+
+	openAISection, err := openaisettings.NewValueSection()
+	require.NoError(t, err)
+	openAIValues, err := values.NewSectionValues(openAISection)
+	require.NoError(t, err)
+	require.NoError(t, values.WithFieldValue("openai-api-key", "base-openai-key-must-not-appear")(openAIValues))
+	parsed.Set(openaisettings.OpenAiChatSlug, openAIValues)
 	return parsed
 }
 
@@ -113,30 +131,15 @@ func findDebugRow(t *testing.T, rows []types.Row, stage, profile string) types.R
 			return row
 		}
 	}
-	t.Fatalf("debug row stage=%q profile=%q not found in %#v", stage, profile, rows)
+	require.FailNowf(t, "debug row not found", "stage=%q profile=%q rows=%#v", stage, profile, rows)
 	return nil
 }
 
 func assertStringSliceCellContains(t *testing.T, row types.Row, key, want string) {
 	t.Helper()
 	got, ok := row.Get(types.FieldName(key))
-	if !ok {
-		t.Fatalf("missing cell %q", key)
-	}
+	require.Truef(t, ok, "missing cell", "%q", key)
 	values, ok := got.([]string)
-	if !ok {
-		t.Fatalf("cell %q: expected []string, got %T (%#v)", key, got, got)
-	}
-	if !containsString(values, want) {
-		t.Fatalf("cell %q: expected %#v to contain %q", key, values, want)
-	}
-}
-
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	require.Truef(t, ok, "unexpected cell type", "%q: expected []string, got %T (%#v)", key, got, got)
+	assert.Contains(t, values, want, "cell %q", key)
 }

--- a/cmd/pinocchio/cmds/profiles/debug_test.go
+++ b/cmd/pinocchio/cmds/profiles/debug_test.go
@@ -7,12 +7,14 @@ import (
 
 	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
 	geppettosections "github.com/go-go-golems/geppetto/pkg/sections"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	openaisettings "github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	glazedconfig "github.com/go-go-golems/glazed/pkg/config"
 	"github.com/go-go-golems/glazed/pkg/types"
 	profilebootstrap "github.com/go-go-golems/pinocchio/pkg/cmds/profilebootstrap"
 	"github.com/go-go-golems/pinocchio/pkg/configdoc"
+	"github.com/go-go-golems/pinocchio/pkg/oauthprofiles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +45,14 @@ profiles:
       chat:
         api_type: openai-responses
         engine: gpt-5
+    extensions:
+      pinocchio.oauth@v1:
+        kind: oauth_bearer
+        authorization_url: https://auth.example.com/authorize
+        token_url: https://auth.example.com/token
+        client_id: pinocchio-test
+        access_token: oauth-access-token-must-not-appear
+        refresh_token: ""
 `)
 
 	cmd, err := NewDebugCommand()
@@ -56,6 +66,8 @@ profiles:
 	assertStringSliceCellContains(t, base, "api_key_status", "openai-api-key=present")
 	final := findDebugRow(t, processor.rows, "final", "assistant")
 	assertStringSliceCellContains(t, final, "api_key_status", "openai-api-key=present")
+	assertStringSliceCellContains(t, final, "oauth_credential_status", "access_token=present")
+	assertStringSliceCellContains(t, final, "oauth_credential_status", "refresh_token=empty")
 	assertCell(t, final, "embedding_type", "openai")
 	assertCell(t, final, "embedding_engine", "text-embedding-3-small")
 	assertCell(t, final, "embedding_dimensions", 1536)
@@ -64,7 +76,23 @@ profiles:
 	require.NoError(t, err)
 	assert.NotContains(t, string(encoded), "test-openai-key-must-not-appear", "debug output leaked a profile API key")
 	assert.NotContains(t, string(encoded), "base-openai-key-must-not-appear", "debug output leaked a base API key")
+	assert.NotContains(t, string(encoded), "oauth-access-token-must-not-appear", "debug output leaked an OAuth access token")
 	assert.Contains(t, string(encoded), "***REDACTED***", "expected --include-settings to contain a redaction marker")
+}
+
+func TestAddOAuthCredentialStatusReportsPresenceWithoutValues(t *testing.T) {
+	row := types.NewRow()
+	addOAuthCredentialStatus(row, &oauthprofiles.Profile{Credential: credentials.Credential{
+		AccessToken:  "access-token-must-not-appear",
+		RefreshToken: "",
+	}})
+
+	status, ok := row.Get("oauth_credential_status")
+	require.True(t, ok)
+	assert.Equal(t, []string{"access_token=present", "refresh_token=empty"}, status)
+	encoded, err := json.Marshal(row)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "access-token-must-not-appear")
 }
 
 func TestDebugProfileLayerRowIncludesLineageProvenance(t *testing.T) {

--- a/cmd/pinocchio/cmds/profiles/root.go
+++ b/cmd/pinocchio/cmds/profiles/root.go
@@ -31,5 +31,15 @@ func NewProfilesCommand() (*cobra.Command, error) {
 	}
 	root.AddCommand(cobraShowCmd)
 
+	debugCmd, err := NewDebugCommand()
+	if err != nil {
+		return nil, err
+	}
+	cobraDebugCmd, err := cli.BuildCobraCommand(debugCmd)
+	if err != nil {
+		return nil, err
+	}
+	root.AddCommand(cobraDebugCmd)
+
 	return root, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -142,9 +142,9 @@ require (
 	google.golang.org/api v0.287.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genai v1.62.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	k8s.io/client-go v0.33.2 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -571,10 +571,14 @@ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgn
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7 h1:41r6JMbpzBMen0R/4TZeeAmGXSJC7DftGINUodzTkPI=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:EIQZ5bFCfRQDV4MhRle7+OgjNtZ6P1PiZBgAKuxXu/Y=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d h1:mpAgMyM9vQHxycBlDq50y1VHpfSfVwzXvrQKtYbXuUY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
 google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
This change introduces a new CLI command, `pinocchio profiles debug`, to help
users diagnose and understand engine profile resolution.

Key features:
- **Profile Resolution Trace**: The command displays the entire process of
  resolving a profile, from source registries to the final effective
settings.
- **Stack Visualization**: It shows each layer of a stacked profile in the
  order it's applied, making complex configurations easier to understand.
- **Settings Stages**: The output includes rows for the base settings, each
  profile layer, the stack-effective settings, and the final merged settings.
- **Secure Credential Reporting**: API keys and other secrets are never
  printed. The command only reports their status (e.g., "present" or
  "empty").
- **Optional Settings Dump**: A new `--include-settings` flag allows
  printing the full, redacted settings as a JSON string for each stage.
- **Comprehensive Tests**: Includes tests to verify correct profile stacking
  and ensure that credential values are properly redacted from the output.